### PR TITLE
Add CLI for CA install

### DIFF
--- a/groove/build.sh
+++ b/groove/build.sh
@@ -11,6 +11,4 @@ mkdir -p build
 (cd proxy && go build -o ../build)
 
 # Python
-rm -rf ./groove-python/groove/assets/ssl
 cp ./build/grooveproxy ./groove-python/groove/assets/grooveproxy
-cp -r ./proxy/ssl ./groove-python/groove/assets/ssl

--- a/groove/groove-python/groove/proxy.py
+++ b/groove/groove-python/groove/proxy.py
@@ -100,8 +100,6 @@ class Groove:
     @contextmanager
     def launch(self):
         parameters = {
-            "--ca-certificate": get_asset_path("ssl/ca.crt"),
-            "--ca-key": get_asset_path("ssl/ca.key"),
             "--port": self.port,
             "--control-port": self.control_port,
             "--proxy-server": self.proxy_server,

--- a/groove/groove.Dockerfile
+++ b/groove/groove.Dockerfile
@@ -39,9 +39,12 @@ RUN cd groove-python && poetry install --no-interaction
 RUN apt-get install -y libnss3-tools
 RUN mkdir -p $HOME/.pki/nssdb
 
-# Install the dependent packages and root certificates
+# Install the dependent packages
 RUN ./setup.sh
 RUN ./build.sh
+
+# Install the root certificates
+RUN cd proxy && go run . install-ca
 
 RUN cd groove-python && poetry run playwright install-deps chromium
 RUN cd groove-python && poetry run playwright install chromium

--- a/groove/proxy/cert.go
+++ b/groove/proxy/cert.go
@@ -4,6 +4,13 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"os/user"
+	"path"
+	"runtime"
 
 	goproxy "github.com/piercefreeman/goproxy"
 )
@@ -23,4 +30,93 @@ func setCA(caCert string, caKey string) error {
 	goproxy.HTTPMitmConnect = &goproxy.ConnectAction{Action: goproxy.ConnectHTTPMitm, TLSConfig: goproxy.TLSConfigFromCA(&goproxyCa)}
 	goproxy.RejectConnect = &goproxy.ConnectAction{Action: goproxy.ConnectReject, TLSConfig: goproxy.TLSConfigFromCA(&goproxyCa)}
 	return nil
+}
+
+func getLocalCAPaths() (localPath string, localCAPath string, localCAKey string) {
+	user, err := user.Current()
+	if err != nil {
+		log.Fatal(fmt.Errorf("Unable to resolve current user: %w", err))
+	}
+
+	localPath = path.Join(user.HomeDir, ".grooveproxy")
+	localCAPath = path.Join(localPath, "ca.crt")
+	localCAKey = path.Join(localPath, "ca.key")
+
+	return localPath, localCAPath, localCAKey
+}
+
+func installCA() {
+	/*
+	 * Determine if a certificate has already been generated for the proxy and if not will create
+	 * one in the user's home directory under `.grooveproxy/{ca.crt,ca.key}`.
+	 */
+	localPath, localCAPath, localCAKey := getLocalCAPaths()
+
+	// Ensure this folder is created
+	if err := os.MkdirAll(localPath, os.ModePerm); err != nil {
+		log.Fatal(err)
+	}
+
+	// Check for existing CA certificates
+	if _, err := os.Stat(localCAPath); err == nil {
+		log.Fatal(fmt.Errorf("CA certificate already generated, remove to regenerate:\n `rm %s && rm %s`\n", localCAPath, localCAKey))
+	}
+
+	cmd := exec.Command("openssl", "genrsa", "-out", "ca.key", "2048")
+	cmd.Dir = localPath
+	if _, err := cmd.Output(); err != nil {
+		log.Fatal(err)
+	}
+
+	cmd = exec.Command("openssl", "req", "-new", "-x509", "-key", "ca.key", "-out", "ca.crt", "-subj", "/C=US/ST=CA/L= /O= /OU= /CN=GrooveProxy/emailAddress= ")
+	cmd.Dir = localPath
+	if _, err := cmd.Output(); err != nil {
+		log.Fatal(err)
+	}
+
+	switch {
+	case runtime.GOOS == "linux":
+		installCALinux(localCAPath)
+	case runtime.GOOS == "darwin":
+		installCADarwin(localCAPath)
+	default:
+		log.Fatal("Unknown OS, can't perform local installation")
+	}
+
+	log.Println("Certificate generation completed.")
+}
+
+func installCALinux(caPath string) {
+	// System installation path
+	user, err := user.Current()
+	if err != nil {
+		log.Fatal(fmt.Errorf("Unable to resolve current user: %w", err))
+	}
+
+	systemPath := "/usr/local/share/ca-certificates/grooveproxy-ca.crt"
+	cmd := exec.Command("sudo", "cp", caPath, systemPath)
+	if _, err = cmd.Output(); err != nil {
+		log.Fatal(err)
+	}
+
+	cmd = exec.Command("sudo", "update-ca-certificates")
+	if _, err = cmd.Output(); err != nil {
+		log.Fatal(err)
+	}
+
+	// Chrome / Chromium doesn't respect the system certificate store on Ubuntu
+	// Instead use
+	// https://chromium.googlesource.com/chromium/src/+/master/docs/linux/cert_management.md
+	certUtilPath := fmt.Sprintf("sql:%s/.pki/nssdb", user.HomeDir)
+	cmd = exec.Command("sudo", "certutil", "-d", certUtilPath, "-A", "-t", "C,,", "-n", "grooveproxy", "-i", systemPath)
+	if _, err = cmd.Output(); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func installCADarwin(caPath string) {
+	cmd := exec.Command("sudo", "security", "add-trusted-cert", "-d", "-p", "ssl", "-p", "basic", "-k", "/Library/Keychains/System.keychain", caPath)
+	if _, err := cmd.Output(); err != nil {
+		log.Fatal(err)
+	}
 }

--- a/groove/setup.sh
+++ b/groove/setup.sh
@@ -1,25 +1,4 @@
 #! /bin/bash
 set -e
 
-cd proxy
-
-go install
-
-openssl genrsa -out ca.key 2048
-openssl req -new -x509 -key ca.key -out ca.crt -subj "/C=US/ST=CA/L= /O= /OU= /CN=GrooveProxy/emailAddress= "
-
-if [ "$(uname)" == "Darwin" ]; then
-    # Mac OS X platform
-    sudo security add-trusted-cert -d -p ssl -p basic -k /Library/Keychains/System.keychain ./ca.crt
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    # GNU/Linux
-    sudo cp ./ca.crt /usr/local/share/ca-certificates/grooveproxy-ca.crt
-    sudo update-ca-certificates
-    sudo certutil -d sql:$HOME/.pki/nssdb -A -t "C,," -n "grooveproxy" -i /usr/local/share/ca-certificates/grooveproxy-ca.crt
-fi
-
-mkdir -p ssl
-cp ca.crt ssl/ca.crt
-cp ca.key ssl/ca.key
-
-cd ..
+(cd proxy && go install)


### PR DESCRIPTION
Make the installation process easier for third party libraries by
extending our executable with a `install-ca` command. This currently
supports installation on MacOS and Ubuntu.