### PR TITLE
Implement and expose proxy setting API

### DIFF
--- a/groove/README.md
+++ b/groove/README.md
@@ -2,9 +2,10 @@
 
 ## Development
 
+Groove is a separate golang executable but it has Python and Node APIs that you often want to co-develop. When developing locally you can make use of the `build.sh` script that will manually build the go project and place it into the necessary bin paths for Python and Node to start using it.
+
 If you'd like to continuously compile changes to the golang proxy in the background:
 
 ```
 cd groove-python && poetry run watchmedo shell-command --command="cd ../ && bash ./build.sh" ../proxy
 ```
-

--- a/groove/groove-node/README.md
+++ b/groove/groove-node/README.md
@@ -22,7 +22,7 @@ npx @piercefreeman/groove install-ca
 ```
 
 ```javascript
-import Groove from '@piercefreeman/groove'
+import { Grove } from '@piercefreeman/groove'
 import { TapeSession } from '@piercefreeman/groove/tape'
 import { fetchWithProxy } from '@piercefreeman/groove/utilities'
 

--- a/groove/groove-node/README.md
+++ b/groove/groove-node/README.md
@@ -11,3 +11,53 @@ Node APIs for Groove, a proxy server built for web crawling and unit test mockin
 - Custom TLS Hello Client support to maintain a Chromium-like TLS handshake while intercepting requests and re-forwarding on packets.
 
 For more information, see the [Github](https://github.com/piercefreeman/grooveproxy) project.
+
+## Usage
+
+Add groove to your project and generate the local certificates.
+
+```
+npm install @piercefreeman/groove
+npx @piercefreeman/groove install-ca
+```
+
+```javascript
+import Groove from '@piercefreeman/groove'
+import { TapeSession } from '@piercefreeman/groove/tape'
+import { fetchWithProxy } from '@piercefreeman/groove/utilities'
+
+const main = async () => {
+    const proxy = new Groove(
+        commandTimeout?;
+        port?;
+        controlPort?;
+        proxyServer?;
+        proxyUsername?;
+        proxyPassword?:;
+    )
+    await proxy.launch()
+
+    const mockedSession = new TapeSession(
+        [
+            {
+                request: {
+                    url: "https://example.com:443/",
+                    method: "GET",
+                    headers: {},
+                    body: Buffer.from(""),
+                },
+                response: {
+                    status: 200,
+                    headers: {},
+                    body: Buffer.from("Test response")
+                }
+            }
+        ]
+    )
+
+    await proxy.tapeLoad(mockedSession);
+
+    const response = await fetchWithProxy("https://example.com", proxy);
+    console.log(response) // "Test response"
+}
+```

--- a/groove/groove-node/index.ts
+++ b/groove/groove-node/index.ts
@@ -28,6 +28,18 @@ export interface EndProxyOptions {
     password?: string;
 }
 
+const checkStatus = async (response: any, echoError: string) => {
+    if (response.status > 300 || response.status < 200) {
+        console.log(`Error: ${response.status}: ${await response.text()}`)
+        throw Error(echoError)
+    }
+
+    const contents = await response.json() as any;
+    if (contents["success"] != true) {
+        throw Error(echoError)
+    }
+}
+
 export class Groove {
     process: any
     executablePath: string | null
@@ -133,10 +145,7 @@ export class Groove {
                 timeout: this.commandTimeout,
             }
         )
-        const contents = await response.json() as any;
-        if (contents["success"] != true) {
-            throw Error("Failed to start recording.")
-        }
+        await checkStatus(response, "Failed to start recording.");
     }
 
     async tapeGet() : Promise<TapeSession> {
@@ -166,10 +175,7 @@ export class Groove {
                 body: formData,
             }
         )
-        const contents = await response.json() as any;
-        if (contents["success"] != true) {
-            throw Error("Failed to load tape.")
-        }
+        await checkStatus(response, "Failed to load tape.");
     }
 
     async tapeStop() {
@@ -180,10 +186,7 @@ export class Groove {
                 timeout: this.commandTimeout,
             }
         )
-        const contents = await response.json() as any;
-        if (contents["success"] != true) {
-            throw Error("Failed to stop recording.")
-        }
+        await checkStatus(response, "Failed to stop recording.");
     }
 
     async setCacheMode(mode: number) {
@@ -195,10 +198,7 @@ export class Groove {
                 body: JSON.stringify({ mode }),
             }
         )
-        const contents = await response.json() as any;
-        if (contents["success"] != true) {
-            throw Error("Failed to set cache mode.")
-        }
+        await checkStatus(response, "Failed to set cache mode.");
     }
 
     async endProxyStart(options: EndProxyOptions) {
@@ -210,10 +210,8 @@ export class Groove {
                 body: JSON.stringify(options),
             }
         )
-        const contents = await response.json() as any;
-        if (contents["success"] != true) {
-            throw Error("Failed to start end proxy.")
-        }
+
+        await checkStatus(response, "Failed to start end-proxy.")
     }
 
     async endProxyStop() {
@@ -224,10 +222,7 @@ export class Groove {
                 timeout: this.commandTimeout,
             }
         )
-        const contents = await response.json() as any;
-        if (contents["success"] != true) {
-            throw Error("Failed to stop end proxy.")
-        }
+        await checkStatus(response, "Failed to stop end-proxy.")
     }
 
     async getExecutablePath() {

--- a/groove/groove-node/install-ca.ts
+++ b/groove/groove-node/install-ca.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import Proxy from './index';
 import { exec } from 'child_process';
 import { promisify } from 'util';

--- a/groove/groove-node/install-ca.ts
+++ b/groove/groove-node/install-ca.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
 
-import Proxy from './index';
+import { Groove } from './index';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 
 const main = async () => {
-    const proxy = new Proxy({});
+    const proxy = new Groove({});
     const executable = await proxy.getExecutablePath();
 
     try {

--- a/groove/groove-node/package-lock.json
+++ b/groove/groove-node/package-lock.json
@@ -7,12 +7,16 @@
     "": {
       "name": "@piercefreeman/groove",
       "version": "1.0.1",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@types/node-fetch": "^2.6.2",
         "form-data": "^4.0.0",
         "https-proxy-agent": "^5.0.1",
         "node-fetch": "^2.6.7"
+      },
+      "bin": {
+        "install-ca": "dist/install-ca.js"
       },
       "devDependencies": {
         "@types/jest": "^29.2.0",

--- a/groove/groove-node/package.json
+++ b/groove/groove-node/package.json
@@ -14,8 +14,10 @@
     "build": "tsc",
     "lint": "eslint .",
     "prepare": "npm run build",
-    "test": "jest .",
-    "install-ca": "node dist/install-ca.js"
+    "test": "jest ."
+  },
+  "bin": {
+    "install-ca": "dist/install-ca.js"
   },
   "author": "",
   "license": "MIT",

--- a/groove/groove-node/tape.ts
+++ b/groove/groove-node/tape.ts
@@ -1,20 +1,20 @@
 import { gunzipSync, gzipSync } from "zlib";
 
 
-interface TapeRequest {
+export interface TapeRequest {
     url: string
     method: string
     headers: Record<string, string[]>
     body: Buffer
 }
 
-interface TapeResponse {
+export interface TapeResponse {
     status: number
     headers: Record<string, string[]>
     body: Buffer
 }
 
-interface TapeRecord {
+export interface TapeRecord {
     request: TapeRequest
     response: TapeResponse
 }
@@ -22,8 +22,8 @@ interface TapeRecord {
 export class TapeSession {
     records: TapeRecord[];
 
-    constructor() {
-        this.records = [];
+    constructor(records?: TapeRecord[]) {
+        this.records = records || [];
     }
 
     async readFromServer(contents: Buffer) {

--- a/groove/groove-node/tests/index.test.ts
+++ b/groove/groove-node/tests/index.test.ts
@@ -1,26 +1,5 @@
 const { default: Groove, CacheModeEnum } = require("../index");
-const HttpsProxyAgent = require('https-proxy-agent');
-const { request } = require("https");
-
-const httpsFetchWithCertificate = async (url: string, configuration: any) : Promise<string> => {
-    return new Promise((resolve, reject) => {
-        request(url, configuration, (response: any) => {
-            let data = "";
-
-            response.on("data", (chunk: any) => {
-                data = data + chunk.toString();
-            });
-          
-            response.on("end", () => {
-                resolve(data);
-            });
-
-            response.on("error", (error: Error) => {
-                reject(error);
-            });
-        }).end();
-    });
-}
+const { fetchWithProxy } = require("../utilities");
 
 describe('testing proxy client', () => {
     let proxy : typeof Groove | null = null;
@@ -38,13 +17,8 @@ describe('testing proxy client', () => {
         await proxy.setCacheMode(CacheModeEnum.OFF);
         await proxy.tapeStart();
 
-        var agent = new HttpsProxyAgent(proxy.baseUrlProxy);
-
-        const contents = await httpsFetchWithCertificate(
-            "https://freeman.vc", {
-                agent,
-                ca: proxy.certificate,
-            }
+        const contents = await fetchWithProxy(
+            "https://freeman.vc", proxy
         );
         expect(contents.length).toBeGreaterThanOrEqual(100);
         await proxy.tapeStop();
@@ -54,11 +28,8 @@ describe('testing proxy client', () => {
         tape.records[0].response.body = Buffer.from("Hello world");
         await proxy.tapeLoad(tape);
 
-        const contentsUpdated = await httpsFetchWithCertificate(
-            "https://freeman.vc", {
-                agent,
-                ca: proxy.certificate,
-            }
+        const contentsUpdated = await fetchWithProxy(
+            "https://freeman.vc", proxy
         )
         expect(contentsUpdated).toBe("Hello world");
     });

--- a/groove/groove-node/tests/index.test.ts
+++ b/groove/groove-node/tests/index.test.ts
@@ -1,4 +1,4 @@
-const { default: Groove, CacheModeEnum } = require("../index");
+const { Groove, CacheModeEnum } = require("../index");
 const { fetchWithProxy } = require("../utilities");
 
 describe('testing proxy client', () => {

--- a/groove/groove-node/utilities.ts
+++ b/groove/groove-node/utilities.ts
@@ -45,7 +45,7 @@ export const streamToBuffer = (stream: any) : Promise<Buffer> => {
 } 
 
 /**
- * @param {import('./index').default} proxy - proxy instance
+ * @param {import('./index').Groove} proxy - proxy instance
  * @param {RequestOptions?} configuration - configuration for the request
  */
 export const fetchWithProxy = async (url: string, proxy: any, configuration: any) : Promise<string> => {

--- a/groove/groove-python/build.py
+++ b/groove/groove-python/build.py
@@ -20,6 +20,9 @@ extensions = [
         #"groove",
         "groove.assets.grooveproxy",
         # Assume we have temporarily copied over the proxy folder into our current path
+        # We don't want it to be referenced in the actual parent library, since we need to bundle
+        # it alongside the python project in sdist in case clients need to build from source
+        # when wheels aren't available.
         "./proxy",
     )
 ]

--- a/groove/groove-python/groove/assets/__init__.py
+++ b/groove/groove-python/groove/assets/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 
 def get_asset_path(asset_name: str) -> Path:
-    return Path(resource_filename(__name__, asset_name))
+    return Path(files(__name__) / asset_name)

--- a/groove/groove-python/groove/proxy.py
+++ b/groove/groove-python/groove/proxy.py
@@ -78,9 +78,6 @@ class Groove:
         command_timeout: int = 5,
         port: int = 6010,
         control_port: int = 6011,
-        proxy_server: str | None = None,
-        proxy_username: str | None = None,
-        proxy_password: str | None = None,
         auth_username: str | None = None,
         auth_password: str | None = None,
     ):
@@ -88,9 +85,6 @@ class Groove:
 
         self.port = port
         self.control_port = control_port
-        self.proxy_server = proxy_server
-        self.proxy_username = proxy_username
-        self.proxy_password = proxy_password
         self.auth_username = auth_username
         self.auth_password = auth_password
 
@@ -104,9 +98,6 @@ class Groove:
         parameters = {
             "--port": self.port,
             "--control-port": self.control_port,
-            "--proxy-server": self.proxy_server,
-            "--proxy-username": self.proxy_username,
-            "--proxy-password": self.proxy_password,
             "--auth-username": self.auth_username,
             "--auth-password": self.auth_password,
         }
@@ -162,6 +153,28 @@ class Groove:
         )
         assert response.json()["success"] == True
 
+    def end_proxy_start(
+        self,
+        proxy_server: str,
+        proxy_username: str | None = None,
+        proxy_password: str | None = None,
+    ):
+        response = self.session.post(
+            urljoin(self.base_url_control, "/api/proxy/start"),
+            json=dict(
+                server=proxy_server,
+                username=proxy_username,
+                password=proxy_password,
+            )
+        )
+        assert response.json()["success"] == True
+
+    def end_proxy_stop(self):
+        response = self.session.post(
+            urljoin(self.base_url_control, "/api/proxy/stop"),
+        )
+        assert response.json()["success"] == True
+        
     @property
     def executable_path(self) -> str:
         # Support statically and dynamically build libraries

--- a/groove/groove-python/groove/tests/test_end_proxy.py
+++ b/groove/groove-python/groove/tests/test_end_proxy.py
@@ -31,8 +31,6 @@ def test_end_proxy(end_proxy, middle_proxy, browser):
     """
     Ensure the proxy can forward to an end proxy
     """
-    middle_proxy.proxy_server = end_proxy.base_url_proxy
-
     record = TapeRecord(
         request=TapeRequest(
             url="https://freeman.vc:443/",
@@ -49,6 +47,8 @@ def test_end_proxy(end_proxy, middle_proxy, browser):
 
     with middle_proxy.launch():
         with end_proxy.launch():
+            middle_proxy.end_proxy_start(end_proxy.base_url_proxy)
+
             end_proxy.tape_load(
                 TapeSession(
                     records=[

--- a/groove/proxy/cache.go
+++ b/groove/proxy/cache.go
@@ -187,9 +187,9 @@ func setupCacheMiddleware(proxy *goproxy.ProxyHttpServer, cache *Cache, recorder
 
 			// If we got here, we couldn't immediately resolve the cache
 			// Determine if we have permission to proceed for this URL
-			log.Println("Will acquire lock")
+			log.Printf("Will acquire lock: %s\n", r.URL.String())
 			cache.AcquireRequestLock(r.URL.String())
-			log.Println("Did acquire lock")
+			log.Printf("Did acquire lock: %s\n", r.URL.String())
 
 			// We now have permission to access this URL and should continue until complete
 			return r, nil
@@ -216,7 +216,9 @@ func setupCacheMiddleware(proxy *goproxy.ProxyHttpServer, cache *Cache, recorder
 				response := responseHistory[i]
 
 				cache.SetValidCacheContents(request, response)
+				log.Printf("Will release lock: %s\n", request.URL.String())
 				cache.ReleaseRequestLock(request.URL.String())
+				log.Printf("Did release lock: %s\n", request.URL.String())
 			}
 
 			return response

--- a/groove/proxy/main.go
+++ b/groove/proxy/main.go
@@ -37,11 +37,6 @@ func main() {
 		caCertificate = flag.String("ca-certificate", "", "Path to CA Certificate")
 		caKey         = flag.String("ca-key", "", "Path to CA Key")
 
-		// Proxy settings for 3rd party proxies
-		proxyServer   = flag.String("proxy-server", "", "3rd party proxy http server")
-		proxyUsername = flag.String("proxy-username", "", "3rd party proxy username")
-		proxyPassword = flag.String("proxy-password", "", "3rd party proxy password")
-
 		// Require authentication to access this proxy
 		//authUsername = flag.String("auth-username", "", "Require authentication to the current server")
 		//authPassword = flag.String("auth-password", "", "Require authentication to the current server")
@@ -63,8 +58,6 @@ func main() {
 		}
 	}
 
-	controller := createController(recorder, cache)
-
 	proxy := goproxy.NewProxyHttpServer()
 	proxy.Verbose = *verbose
 
@@ -85,9 +78,10 @@ func main() {
 
 	// Fingerprint mimic logic
 	roundTripper := newRoundTripper()
-	if len(*proxyServer) > 0 {
-		setupEndProxyMiddleware(proxy, roundTripper, *proxyServer, *proxyUsername, *proxyPassword)
-	}
+	endProxy := newEndProxy(proxy)
+	endProxy.setupMiddleware(roundTripper)
+
+	controller := createController(recorder, cache, endProxy)
 
 	proxy.RoundTripper = http.RoundTripper(roundTripper)
 


### PR DESCRIPTION
We define an end proxy as a 3rd party proxy server that we route requests through in a non-MITM style. Instead of launching the grooveproxy with static end proxy values, ticket https://github.com/piercefreeman/grooveproxy/issues/21 gives the justification for why we should make these proxy servers dynamically settable by clients.

There shouldn't be any downsides or race conditions introduced by this approach. Once a request is in-flight we don't have any adverse affect by hot-swapping out the proxy server - since the fresh dial with the new proxy server will only be utilized for future requests.

This PR adds the server and client logic for updating these proxies dynamically.