### PR TITLE
Add passthrough request handlers

### DIFF
--- a/groove/groove-node/dialer.ts
+++ b/groove/groove-node/dialer.ts
@@ -1,0 +1,36 @@
+
+
+export interface RequestRequiresDefinition {
+    urlRegex: string
+    resourceTypes: string[]
+}
+
+export interface ProxyDefinition {
+    url: string
+    username?: string
+    password?: string
+}
+
+export interface DialerDefinition {
+    priority: number
+    proxy?: ProxyDefinition
+    requestRequires?: RequestRequiresDefinition
+}
+
+export const DefaultInternetDialer: DialerDefinition = {
+    /*
+     * Proxy all requests to the open internet, with low priority
+     */
+    priority: 1,
+}
+
+export const DefaultLocalPassthroughDialer: DialerDefinition = {
+    /*
+     * Proxy generally static assets to the open internet, with high priority
+     */
+    priority: 1000,
+    requestRequires: {
+        urlRegex: ".*?.(?:txt|json|css|less|js|mjs|cjs|gif|ico|jpe?g|svg|png|webp|mkv|mp4|mpe?g|webm|eot|ttf|woff2?)",
+        resourceTypes: ["script", "image", "stylesheet", "media", "font"],
+    }
+}

--- a/groove/groove-node/index.ts
+++ b/groove/groove-node/index.ts
@@ -7,7 +7,7 @@ import { fetchWithTimeout, sleep, streamToBuffer } from './utilities';
 import { TapeSession } from './tape';
 import { homedir } from 'os';
 import FormData from 'form-data';
-import { DialerDefinition } from './dialer';
+import { DialerDefinition, DefaultInternetDialer } from './dialer';
 
 export const CacheModeEnum = {
 	OFF: 0,

--- a/groove/groove-node/index.ts
+++ b/groove/groove-node/index.ts
@@ -7,6 +7,7 @@ import { fetchWithTimeout, sleep, streamToBuffer } from './utilities';
 import { TapeSession } from './tape';
 import { homedir } from 'os';
 import FormData from 'form-data';
+import { DialerDefinition } from './dialer';
 
 export const CacheModeEnum = {
 	OFF: 0,
@@ -201,13 +202,26 @@ export class Groove {
         await checkStatus(response, "Failed to set cache mode.");
     }
 
-    async endProxyStart(options: EndProxyOptions) {
+    async dialerLoad(dialers: DialerDefinition[]) {
         const response = await fetchWithTimeout(
-            `${this.baseUrlControl}/api/proxy/start`,
+            `${this.baseUrlControl}/api/dialer/load`,
             {
                 method: "POST",
                 timeout: this.commandTimeout,
-                body: JSON.stringify(options),
+                body: JSON.stringify(
+                    {
+                        definitions: dialers.map(
+                            (dialer) => ({
+                                priority: dialer.priority,
+                                proxyServer: dialer.proxy ? dialer.proxy.url : null,
+                                proxyUsername: dialer.proxy ? dialer.proxy.username : null,
+                                proxyPassword: dialer.proxy ? dialer.proxy.password : null,
+                                requiresUrlRegex: dialer.requestRequires ? dialer.requestRequires.urlRegex : null,
+                                requiresResourceTypes: dialer.requestRequires ? dialer.requestRequires.resourceTypes : null,
+                            })
+                        )
+                    }
+                ),
             }
         )
 

--- a/groove/groove-python/benchmark_end_proxy.py
+++ b/groove/groove-python/benchmark_end_proxy.py
@@ -1,0 +1,72 @@
+"""
+Benchmark the load performance of a 3rd party proxy provider
+
+"""
+from time import time
+
+from click import command, option, secho
+from playwright.sync_api import sync_playwright
+
+from groove.dialer import (DefaultLocalPassthroughDialer, DialerDefinition,
+                           ProxyDefinition)
+from groove.proxy import Groove
+
+
+def handle(route, request):
+    resource_type = request.resource_type
+
+    # override headers
+    headers = {
+        **request.headers,
+        "Resource-Type": resource_type,
+    }
+    route.continue_(headers=headers)
+
+
+@command()
+@option("--url", required=True)
+@option("--proxy-server", required=True)
+@option("--proxy-username", required=True)
+@option("--proxy-password", required=True)
+def benchmark(url, proxy_server, proxy_username, proxy_password):
+    groove = Groove(port=6040, control_port=6041)
+
+    with groove.launch():
+        with sync_playwright() as p:
+            groove.dialer_load(
+                [
+                    DefaultLocalPassthroughDialer(),
+                    DialerDefinition(
+                        priority=DefaultLocalPassthroughDialer().priority - 1,
+                        proxy=ProxyDefinition(
+                            url=proxy_server,
+                            username=proxy_username,
+                            password=proxy_password,
+                        ),
+                    )
+                ]
+            )
+
+            browser = p.chromium.launch(
+                headless=False,
+            )
+
+            context = browser.new_context(
+                proxy={
+                    "server": groove.base_url_proxy,
+                }
+            )
+
+            page = context.new_page()
+
+            page.route("**/*", handle)
+
+            start = time()
+            page.goto(url, timeout=60000)
+            end = time()
+            print(f"Time taken: {end - start}")
+
+            browser.close()
+
+if __name__ == '__main__':
+    benchmark()

--- a/groove/groove-python/groove/dialer.py
+++ b/groove/groove-python/groove/dialer.py
@@ -1,0 +1,44 @@
+from pydantic import BaseModel, validator
+
+
+class RequestRequiresDefinition(BaseModel):
+    url_regex: str
+    resource_types: list[str]
+
+
+class ProxyDefinition(BaseModel):
+    url: str
+    username: str | None = None
+    password: str | None = None
+
+
+class DialerDefinition(BaseModel):
+    priority: int
+    proxy: ProxyDefinition | None = None
+    request_requires: RequestRequiresDefinition | None = None
+
+
+class DefaultInternetDialer(DialerDefinition):
+    """
+    Proxy all requests to the open internet, with low priority
+    """
+    def __init__(self):
+        super().__init__(
+            priority=1,
+            proxy=None,
+            request_requires=None,
+        )
+
+class DefaultLocalPassthroughDialer(DialerDefinition):
+    """
+    Proxy generally static assets to the open internet, with high priority
+    """
+    def __init__(self):
+        super().__init__(
+            priority=1000,
+            proxy=None,
+            request_requires=RequestRequiresDefinition(
+                url_regex=".*?.(?:txt|json|css|less|js|mjs|cjs|gif|ico|jpe?g|svg|png|webp|mkv|mp4|mpe?g|webm|eot|ttf|woff2?)",
+                resource_types=["script", "image", "stylesheet", "media", "font"],
+            ),
+        )

--- a/groove/groove-python/groove/dialer.py
+++ b/groove/groove-python/groove/dialer.py
@@ -1,18 +1,18 @@
-from pydantic import BaseModel, validator
+from groove.models import GrooveModelBase
 
 
-class RequestRequiresDefinition(BaseModel):
+class RequestRequiresDefinition(GrooveModelBase):
     url_regex: str
     resource_types: list[str]
 
 
-class ProxyDefinition(BaseModel):
+class ProxyDefinition(GrooveModelBase):
     url: str
     username: str | None = None
     password: str | None = None
 
 
-class DialerDefinition(BaseModel):
+class DialerDefinition(GrooveModelBase):
     priority: int
     proxy: ProxyDefinition | None = None
     request_requires: RequestRequiresDefinition | None = None

--- a/groove/groove-python/groove/enums.py
+++ b/groove/groove-python/groove/enums.py
@@ -1,5 +1,6 @@
 from enum import Enum
 
+
 class CacheModeEnum(Enum):
     # Ensure enum values are aligned with the cache.go definitions
     OFF = 0

--- a/groove/groove-python/groove/models.py
+++ b/groove/groove-python/groove/models.py
@@ -1,0 +1,7 @@
+from humps import camelize
+from pydantic import BaseModel
+
+class GrooveModelBase(BaseModel):
+    class Config:
+        alias_generator = camelize
+        allow_population_by_field_name = True

--- a/groove/groove-python/groove/models.py
+++ b/groove/groove-python/groove/models.py
@@ -1,6 +1,7 @@
 from humps import camelize
 from pydantic import BaseModel
 
+
 class GrooveModelBase(BaseModel):
     class Config:
         alias_generator = camelize

--- a/groove/groove-python/groove/proxy.py
+++ b/groove/groove-python/groove/proxy.py
@@ -100,18 +100,17 @@ class Groove:
         assert response.json()["success"] == True
 
     def dialers_load(self, dialers: list[DialerDefinition]):
-        print("WHEE", urljoin(self.base_url_control, "/api/dialer/load"))
         response = self.session.post(
             urljoin(self.base_url_control, "/api/dialer/load"),
             json=dict(
                 definitions=[
                     {
                         "priority": dialer.priority,
-                        "proxy_server": dialer.proxy.url if dialer.proxy is not None else None,
-                        "proxy_username": dialer.proxy.url if dialer.proxy is not None else None,
-                        "proxy_password": dialer.proxy.url if dialer.proxy is not None else None,
-                        "requires_url_regex": dialer.request_requires.url_regex if dialer.request_requires is not None else None,
-                        "requires_resource_types": dialer.request_requires.resource_types if dialer.request_requires is not None else None,
+                        "proxyServer": dialer.proxy.url if dialer.proxy is not None else None,
+                        "proxyUsername": dialer.proxy.username if dialer.proxy is not None else None,
+                        "proxyPassword": dialer.proxy.password if dialer.proxy is not None else None,
+                        "requiresUrlRegex": dialer.request_requires.url_regex if dialer.request_requires is not None else None,
+                        "requiresResourceTypes": dialer.request_requires.resource_types if dialer.request_requires is not None else None,
                     }
                     for dialer in dialers
                 ],

--- a/groove/groove-python/groove/proxy.py
+++ b/groove/groove-python/groove/proxy.py
@@ -11,7 +11,7 @@ from requests import Session
 from groove.assets import get_asset_path
 from groove.enums import CacheModeEnum
 from groove.tape import TapeSession
-from groove.dialer import DialerDefinition
+from groove.dialer import DialerDefinition, DefaultInternetDialer
 
 
 class ProxyFailureError(Exception):
@@ -99,7 +99,7 @@ class Groove:
         )
         assert response.json()["success"] == True
 
-    def dialers_load(self, dialers: list[DialerDefinition]):
+    def dialer_load(self, dialers: list[DialerDefinition]):
         response = self.session.post(
             urljoin(self.base_url_control, "/api/dialer/load"),
             json=dict(

--- a/groove/groove-python/groove/proxy.py
+++ b/groove/groove-python/groove/proxy.py
@@ -1,6 +1,5 @@
 from contextlib import contextmanager
 from enum import Enum
-
 from subprocess import Popen
 from sysconfig import get_config_var
 from time import sleep
@@ -9,9 +8,9 @@ from urllib.parse import urljoin
 from requests import Session
 
 from groove.assets import get_asset_path
+from groove.dialer import DefaultInternetDialer, DialerDefinition
 from groove.enums import CacheModeEnum
 from groove.tape import TapeSession
-from groove.dialer import DialerDefinition, DefaultInternetDialer
 
 
 class ProxyFailureError(Exception):

--- a/groove/groove-python/groove/tape.py
+++ b/groove/groove-python/groove/tape.py
@@ -1,8 +1,11 @@
-from pydantic import validator
+from base64 import b64decode, b64encode
 from gzip import compress, decompress
 from json import dumps, loads
-from base64 import b64decode, b64encode
+
+from pydantic import validator
+
 from groove.models import GrooveModelBase
+
 
 class TapeRequest(GrooveModelBase):
     url: str

--- a/groove/groove-python/groove/tape.py
+++ b/groove/groove-python/groove/tape.py
@@ -1,9 +1,10 @@
-from pydantic import BaseModel, validator
+from pydantic import validator
 from gzip import compress, decompress
 from json import dumps, loads
 from base64 import b64decode, b64encode
+from groove.models import GrooveModelBase
 
-class TapeRequest(BaseModel):
+class TapeRequest(GrooveModelBase):
     url: str
     method: str
     headers: dict[str, list[str]]
@@ -14,7 +15,7 @@ class TapeRequest(BaseModel):
         return b64decode(value)
 
 
-class TapeResponse(BaseModel):
+class TapeResponse(GrooveModelBase):
     status: int
     headers: dict[str, list[str]]
     body: bytes
@@ -24,7 +25,7 @@ class TapeResponse(BaseModel):
         return b64decode(value)
 
 
-class TapeRecord(BaseModel):
+class TapeRecord(GrooveModelBase):
     request: TapeRequest
     response: TapeResponse
 
@@ -35,7 +36,7 @@ class TapeRecord(BaseModel):
         }
 
 
-class TapeSession(BaseModel):
+class TapeSession(GrooveModelBase):
     records: list[TapeRecord]
 
     @classmethod

--- a/groove/groove-python/groove/tests/test_auth.py
+++ b/groove/groove-python/groove/tests/test_auth.py
@@ -7,7 +7,7 @@ from requests import get
 
 from groove.assets import get_asset_path
 from groove.proxy import Groove
-from groove.tape import  TapeRecord, TapeRequest, TapeResponse, TapeSession
+from groove.tape import TapeRecord, TapeRequest, TapeResponse, TapeSession
 
 AUTH_USERNAME = "test-username"
 AUTH_PASSWORD = "test-password"

--- a/groove/groove-python/groove/tests/test_end_proxy.py
+++ b/groove/groove-python/groove/tests/test_end_proxy.py
@@ -5,6 +5,7 @@ from bs4 import BeautifulSoup
 
 from groove.proxy import Groove
 from groove.tape import TapeRecord, TapeRequest, TapeResponse, TapeSession
+from groove.dialer import DialerDefinition, ProxyDefinition
 
 
 AUTH_USERNAME = "test-username"
@@ -47,7 +48,17 @@ def test_end_proxy(end_proxy, middle_proxy, browser):
 
     with middle_proxy.launch():
         with end_proxy.launch():
-            middle_proxy.end_proxy_start(end_proxy.base_url_proxy)
+            # Route everything to the proxy
+            middle_proxy.dialers_load(
+                [
+                    DialerDefinition(
+                        priority=1,
+                        proxy=ProxyDefinition(
+                            url=end_proxy.base_url_proxy
+                        )
+                    )
+                ]
+            )
 
             end_proxy.tape_load(
                 TapeSession(

--- a/groove/groove-python/groove/tests/test_end_proxy.py
+++ b/groove/groove-python/groove/tests/test_end_proxy.py
@@ -3,10 +3,9 @@ from base64 import b64encode
 import pytest
 from bs4 import BeautifulSoup
 
+from groove.dialer import DialerDefinition, ProxyDefinition
 from groove.proxy import Groove
 from groove.tape import TapeRecord, TapeRequest, TapeResponse, TapeSession
-from groove.dialer import DialerDefinition, ProxyDefinition
-
 
 AUTH_USERNAME = "test-username"
 AUTH_PASSWORD = "test-password"
@@ -49,7 +48,7 @@ def test_end_proxy(end_proxy, middle_proxy, browser):
     with middle_proxy.launch():
         with end_proxy.launch():
             # Route everything to the proxy
-            middle_proxy.dialers_load(
+            middle_proxy.dialer_load(
                 [
                     DialerDefinition(
                         priority=1,

--- a/groove/groove-python/poetry.lock
+++ b/groove/groove-python/poetry.lock
@@ -216,6 +216,14 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pyhumps"
+version = "3.8.0"
+description = "🐫  Convert strings (and dictionary keys) between snake case, camel case and pascal case in Python. Inspired by Humps for Node"
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyparsing"
 version = "3.0.9"
 description = "pyparsing module - Classes and methods to define and execute parsing grammars"
@@ -352,7 +360,7 @@ watchmedo = ["PyYAML (>=3.10)"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.10"
-content-hash = "ba1b131ec1267aaf3619d2b22d6eef13318102f253de3ab4ffcaf05d93e701b8"
+content-hash = "a700babf45cd58107b2cf44d2b2743e00902aeb90f224a9339bd34626b5ceaca"
 
 [metadata.files]
 anyio = [
@@ -521,6 +529,10 @@ pydantic = [
 pyee = [
     {file = "pyee-8.1.0-py2.py3-none-any.whl", hash = "sha256:383973b63ad7ed5e3c0311f8b179c52981f9e7b3eaea0e9a830d13ec34dde65f"},
     {file = "pyee-8.1.0.tar.gz", hash = "sha256:92dacc5bd2bdb8f95aa8dd2585d47ca1c4840e2adb95ccf90034d64f725bfd31"},
+]
+pyhumps = [
+    {file = "pyhumps-3.8.0-py3-none-any.whl", hash = "sha256:060e1954d9069f428232a1adda165db0b9d8dfdce1d265d36df7fbff540acfd6"},
+    {file = "pyhumps-3.8.0.tar.gz", hash = "sha256:498026258f7ee1a8e447c2e28526c0bea9407f9a59c03260aee4bd6c04d681a3"},
 ]
 pyparsing = [
     {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},

--- a/groove/groove-python/pyproject.toml
+++ b/groove/groove-python/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.10"
 pydantic = "^1.10.2"
 requests = "^2.28.1"
 beautifulsoup4 = "^4.11.1"
+pyhumps = "^3.8.0"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/groove/proxy/controller.go
+++ b/groove/proxy/controller.go
@@ -19,7 +19,7 @@ type ProxyRequest struct {
 	Password string `json:"password"`
 }
 
-func createController(recorder *Recorder, cache *Cache, endProxy *EndProxy) *gin.Engine {
+func createController(recorder *Recorder, cache *Cache, dialerSession *DialerSession) *gin.Engine {
 	router := gin.Default()
 	router.POST("/api/tape/record", func(c *gin.Context) {
 		// Start to record the requests, nullifying any ones from an old session
@@ -93,7 +93,7 @@ func createController(recorder *Recorder, cache *Cache, endProxy *EndProxy) *gin
 		})
 	})
 
-	router.POST("/api/proxy/start", func(c *gin.Context) {
+	/*router.POST("/api/dialer/add", func(c *gin.Context) {
 		var request ProxyRequest
 		err := json.NewDecoder(c.Request.Body).Decode(&request)
 
@@ -110,15 +110,7 @@ func createController(recorder *Recorder, cache *Cache, endProxy *EndProxy) *gin
 		c.JSON(http.StatusOK, gin.H{
 			"success": true,
 		})
-	})
-
-	router.POST("/api/proxy/stop", func(c *gin.Context) {
-		endProxy.disableProxy()
-
-		c.JSON(http.StatusOK, gin.H{
-			"success": true,
-		})
-	})
+	})*/
 
 	return router
 }

--- a/groove/proxy/controller.go
+++ b/groove/proxy/controller.go
@@ -16,12 +16,12 @@ type CacheModeRequest struct {
 type DialerDefinitionRequest struct {
 	Priority int `json:"priority"`
 
-	ProxyServer   string `json:"proxy_server"`
-	ProxyUsername string `json:"proxy_username"`
-	ProxyPassword string `json:"proxy_password"`
+	ProxyServer   string `json:"proxyServer"`
+	ProxyUsername string `json:"proxyUsername"`
+	ProxyPassword string `json:"proxyPassword"`
 
-	RequiresUrlRegex      string   `json:"requires_url_regex"`
-	RequiresResourceTypes []string `json:"requires_resource_types"`
+	RequiresUrlRegex      string   `json:"requiresUrlRegex"`
+	RequiresResourceTypes []string `json:"requiresResourceTypes"`
 }
 
 type DialerDefinitionRequests struct {

--- a/groove/proxy/dialers.go
+++ b/groove/proxy/dialers.go
@@ -20,7 +20,9 @@ type RequestRequiresDefinition struct {
 	resourceTypes []string
 }
 
-const ProxyResourceType = "Proxy-Resource-Type"
+// Don't prefix with `Prefix` - chromium appears to have specific manipulation
+// routines when a header is prefixed with `Proxy-`
+const ProxyResourceType = "Resource-Type"
 
 func NewRequestRequiresDefinition(urlRegex string, resourceTypes []string) (*RequestRequiresDefinition, error) {
 	expression, err := regexp.Compile(urlRegex)

--- a/groove/proxy/dialers.go
+++ b/groove/proxy/dialers.go
@@ -1,0 +1,258 @@
+package main
+
+import (
+	"log"
+	"math/rand"
+	"net"
+	"net/http"
+	"net/url"
+	"regexp"
+
+	"github.com/google/uuid"
+)
+
+type RequestRequiresDefinition struct {
+	/*
+	 * OR listing of what the request requires to be valid
+	 * If RequestRequires is not nil, then the request must match at least one of the following
+	 */
+	urlRegex      *regexp.Regexp
+	resourceTypes []string
+}
+
+const ProxyResourceType = "Proxy-Resource-Type"
+
+func NewRequestRequiresDefinition(urlRegex string, resourceTypes []string) (*RequestRequiresDefinition, error) {
+	expression, err := regexp.Compile(urlRegex)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &RequestRequiresDefinition{
+		urlRegex:      expression,
+		resourceTypes: resourceTypes,
+	}, nil
+}
+
+func (definition *RequestRequiresDefinition) IsRequestValid(request *http.Request) bool {
+	/*
+	 * Check if the request meets the requirements of this definition
+	 */
+	if definition.urlRegex != nil {
+		if definition.urlRegex.MatchString(request.URL.String()) {
+			log.Printf("Request URL matches regex %s", request.URL.String())
+			return true
+		}
+	}
+
+	if len(definition.resourceTypes) > 0 {
+		requestType := request.Header.Get(ProxyResourceType)
+
+		for _, resourceType := range definition.resourceTypes {
+			if requestType == resourceType {
+				log.Printf("Resource type matches %s", requestType)
+				return true
+			}
+		}
+	}
+
+	log.Println("No request match found")
+	return false
+}
+
+type ProxyDefinition struct {
+	url string
+
+	// Use blank values for no authentication
+	username string
+	password string
+}
+
+type DialerDefinition struct {
+	/*
+	 * A single distance of a end-host dialer. This dial is responsible for opening
+	 * up the actual http.Connection to the open internet.
+	 */
+	identifier string
+
+	// The highest priority dialer is the one that will be used first
+	priority int
+
+	// If provided will try to connect through a 3rd party proxy
+	// If nil will use passthrough support from the machine that hosts groove
+	proxy *ProxyDefinition
+
+	// Filter of when this dialer should be used
+	// If provided will ensure that at least one condition is met
+	// If not provided, will always be a candidate
+	requestRequires *RequestRequiresDefinition
+
+	Dial func(network, addr string) (net.Conn, error)
+}
+
+func NewDialerDefinition(
+	priority int,
+	proxy *ProxyDefinition,
+	requestRequires *RequestRequiresDefinition,
+) *DialerDefinition {
+	// Allocate the dialer up-front so this is cached in the definition for later use
+	var dialer func(network, addr string) (net.Conn, error)
+
+	if proxy != nil {
+		if len(proxy.username) > 0 && len(proxy.password) > 0 {
+			log.Println("Creating authenticated end proxy dialer...")
+
+			connectReqHandler := func(req *http.Request) {
+				log.Printf("Will set basic auth on proxy connect %s %s\n", proxy.username, proxy.password)
+				SetBasicAuth(proxy.username, proxy.password, req)
+			}
+			// This is an unideal dependency to have since the dialer doesn't really relate to the proxy
+			// other than forwarding some dial through the proxy's built-in dialer
+			dialer = NewConnectDialToProxyWithHandler(proxy.url, connectReqHandler)
+		} else {
+			log.Println("Creating unauthenticated end proxy dialer...")
+			dialer = NewConnectDialToProxyWithHandler(proxy.url, nil)
+		}
+
+	} else {
+		dialer = net.Dial
+	}
+
+	return &DialerDefinition{
+		identifier:      uuid.New().String(),
+		priority:        priority,
+		proxy:           proxy,
+		requestRequires: requestRequires,
+		Dial:            dialer,
+	}
+}
+
+func (definition *DialerDefinition) GetHost(request *http.Request) string {
+	// Returns the effective "host" for a given request
+	// This is just intended to be used as a key for caching attributes about the
+	// given connection stream that's opened once we dial
+	if definition.proxy != nil {
+		url, _ := url.Parse(definition.proxy.url)
+		return url.Host
+	}
+
+	return request.URL.Host
+}
+
+type DialerContext struct {
+	/*
+	 * Context for an individual dial lifecycle, allows us to keep track of some state
+	 * when trying multiple dials in a row
+	 */
+
+	// If provided, will filter for dialers that are compatible with this request
+	// If blank, will assume that
+	Request *http.Request
+
+	// List of DialDefinitions that we have already tried
+	attemptedDialIdentifiers []string
+
+	// Remaining dials that are available
+	remainingTries int
+}
+
+type DialerSession struct {
+	/*
+	 * Primary object and storage structure for dial generation. Only one of these should
+	 * be instantiated per groove instance.
+	 */
+	dialerDefinitions []*DialerDefinition
+
+	// Attempts allowed in each context to dial a successful connection to the open internet
+	totalTries int
+
+	// NOTE: In the future this might store some mapping of
+	// (dialer definition, host) -> success probabilities
+}
+
+func NewDialerSession() *DialerSession {
+	return &DialerSession{
+		dialerDefinitions: make([]*DialerDefinition, 0),
+	}
+}
+
+func (session *DialerSession) AddDialerDefinition(dialerDefinition *DialerDefinition) {
+	session.dialerDefinitions = append(session.dialerDefinitions, dialerDefinition)
+}
+
+func (session *DialerSession) NewDialerContext(request *http.Request) *DialerContext {
+	return &DialerContext{
+		Request:        request,
+		remainingTries: len(session.dialerDefinitions),
+	}
+}
+
+func (session *DialerSession) candidateDialers(context *DialerContext) []*DialerDefinition {
+	/*
+	 * Returns a list of dialers that can be used to fulfill the request
+	 * param: request - nil if we don't know the request yet, true if we just need to open
+	 * 	a connection over the wire for a non-http protocol like for websockets
+	 */
+	candidateDialers := session.dialerDefinitions
+
+	// If request is provided, attempt to filter for the possible dialers
+	if context.Request != nil {
+		candidateDialers = filterSlice(
+			candidateDialers,
+			func(dialer *DialerDefinition) bool {
+				return dialer.requestRequires == nil || (dialer.requestRequires != nil && dialer.requestRequires.IsRequestValid(context.Request))
+			},
+		)
+	}
+
+	// Otherwise filter out dials that have been already tried
+	candidateDialers = filterSlice(
+		candidateDialers,
+		func(dialer *DialerDefinition) bool {
+			return !containsString(context.attemptedDialIdentifiers, dialer.identifier)
+		},
+	)
+
+	return candidateDialers
+}
+
+func (session *DialerSession) NextDialer(context *DialerContext) *DialerDefinition {
+	/*
+	 * Primary method exposed from the session and the only one that clients should have to utilize
+	 * Returns the next allowed dialer to use for the given context, nil if not supported
+	 */
+	if context.remainingTries <= 0 {
+		return nil
+	}
+
+	candidateDialers := session.candidateDialers(context)
+
+	// Choose the one with maximum priority
+	maxPriority := 0
+	for _, dialer := range candidateDialers {
+		if dialer.priority > maxPriority {
+			maxPriority = dialer.priority
+		}
+	}
+
+	// Choose one within this larger group
+	maxPriorityDialers := filterSlice(
+		candidateDialers,
+		func(dialer *DialerDefinition) bool {
+			return dialer.priority == maxPriority
+		},
+	)
+
+	if len(maxPriorityDialers) == 0 {
+		return nil
+	}
+
+	dialer := maxPriorityDialers[rand.Intn(len(maxPriorityDialers))]
+
+	// Decrement the remaining tries
+	context.remainingTries -= 1
+	context.attemptedDialIdentifiers = append(context.attemptedDialIdentifiers, dialer.identifier)
+
+	return dialer
+}

--- a/groove/proxy/go.mod
+++ b/groove/proxy/go.mod
@@ -2,12 +2,12 @@ module grooveproxy
 
 go 1.18
 
-replace github.com/piercefreeman/goproxy => /Users/piercefreeman/projects/goproxy
+// replace github.com/piercefreeman/goproxy => /Users/piercefreeman/projects/goproxy
 
 require (
 	github.com/gin-gonic/gin v1.8.1
 	github.com/google/uuid v1.3.0
-	github.com/piercefreeman/goproxy v0.0.6
+	github.com/piercefreeman/goproxy v0.0.7
 	github.com/pquerna/cachecontrol v0.1.0
 	github.com/refraction-networking/utls v1.1.5
 	golang.org/x/net v0.0.0-20221012135044-0b7e1fb9d458

--- a/groove/proxy/go.mod
+++ b/groove/proxy/go.mod
@@ -2,10 +2,11 @@ module grooveproxy
 
 go 1.18
 
-// replace github.com/piercefreeman/goproxy => /Users/piercefreeman/projects/goproxy
+replace github.com/piercefreeman/goproxy => /Users/piercefreeman/projects/goproxy
 
 require (
 	github.com/gin-gonic/gin v1.8.1
+	github.com/google/uuid v1.3.0
 	github.com/piercefreeman/goproxy v0.0.6
 	github.com/pquerna/cachecontrol v0.1.0
 	github.com/refraction-networking/utls v1.1.5

--- a/groove/proxy/go.sum
+++ b/groove/proxy/go.sum
@@ -22,6 +22,8 @@ github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaS
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/klauspost/compress v1.15.9 h1:wKRjX6JRtDdrE9qwa4b/Cip7ACOshUI4smpCQanqjSY=
@@ -44,8 +46,6 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
-github.com/piercefreeman/goproxy v0.0.6 h1:wxXi37FHz0VHswlhlGMO5IC3yxwjq7cUfiRnc+4FvKA=
-github.com/piercefreeman/goproxy v0.0.6/go.mod h1:l5HLvLDhJ/BRwyAg1MZI7X0wKuyrFqCX7flLI11zsqg=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/groove/proxy/go.sum
+++ b/groove/proxy/go.sum
@@ -46,6 +46,8 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
+github.com/piercefreeman/goproxy v0.0.7 h1:rHe+ZUPzQtgameEBLIEGQUxxjlan2HboHg572cGv3qQ=
+github.com/piercefreeman/goproxy v0.0.7/go.mod h1:l5HLvLDhJ/BRwyAg1MZI7X0wKuyrFqCX7flLI11zsqg=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/groove/proxy/main.go
+++ b/groove/proxy/main.go
@@ -79,29 +79,11 @@ func main() {
 
 	dialerSession := NewDialerSession()
 
-	// TODO: Update to a client side configuration
-	resources := make([]string, 0)
-	resources = append(resources, "stylesheet")
-
-	resourceDefinition, _ := NewRequestRequiresDefinition(
-		".*?.(?:txt|json|css|less|js|mjs|cjs|gif|ico|jpe?g|svg|png|webp|mkv|mp4|mpe?g|webm|eot|ttf|woff2?)",
-		resources,
-	)
-
-	dialerSession.AddDialerDefinition(
-		NewDialerDefinition(100, nil, resourceDefinition),
-		//NewDialerDefinition(100, nil, nil),
-	)
-	dialerSession.AddDialerDefinition(
-		NewDialerDefinition(
-			10,
-			&ProxyDefinition{
-				url:      "XXX",
-				username: "XXX",
-				password: "XXX",
-			},
-			nil,
-		),
+	// Default the session to a full passthrough from local -> Internet
+	// This will get overridden by clients when they provide values
+	dialerSession.DialerDefinitions = append(
+		dialerSession.DialerDefinitions,
+		NewDialerDefinition(0, nil, nil),
 	)
 
 	roundTripper := NewCustomRoundTripper(dialerSession)

--- a/groove/proxy/transport.go
+++ b/groove/proxy/transport.go
@@ -1,26 +1,8 @@
-/*
- * Copyright (c) 2019 Yawning Angel <yawning at schwanenlied dot me>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <https://www.gnu.org/licenses/>.
- */
-
 package main
 
 import (
 	"crypto/tls"
 	"errors"
-	"fmt"
 	"log"
 	"net"
 	"net/http"
@@ -32,139 +14,212 @@ import (
 	"golang.org/x/net/http2"
 )
 
-var errProtocolNegotiated = errors.New("meek_lite: protocol negotiated")
+type CustomRoundTripper struct {
+	/*
+	 * Generator session for global round-trips
+	 * - Support utls handshakes with remote server
+	 */
 
-type roundTripper struct {
-	sync.Mutex
+	// Mapping of host->protocol. Note that this is the actual "host" of the dial, might
+	// be the end host itself or the proxy server.
+	// ProtocolHTTP1 | ProtocolHTTP1TLS | ProtocolHTTP2TLS
+	protocolMap  map[string]int
+	protocolLock sync.RWMutex
 
-	transport http.RoundTripper
-
-	initConn net.Conn
-
-	Dialer func(network string, addr string) (net.Conn, error)
+	// Dialer session
+	dialerSession *DialerSession
 }
 
-func (rt *roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Note: This isn't protected with a lock, since the meeklite ioWorker
-	// serializes RoundTripper requests.
-	//
-	// This also assumes that req.URL.Host will remain constant for the
-	// lifetime of the roundTripper, which is a valid assumption for meeklite.
-	if rt.transport == nil {
-		if err := rt.getTransport(req); err != nil {
-			return nil, err
-		}
+const (
+	ProtocolHTTP1    = iota
+	ProtocolHTTP1TLS = iota
+	ProtocolHTTP2TLS = iota
+)
+
+func NewCustomRoundTripper(dialerSession *DialerSession) *CustomRoundTripper {
+	return &CustomRoundTripper{
+		protocolMap:   make(map[string]int),
+		dialerSession: dialerSession,
 	}
-	return rt.transport.RoundTrip(req)
 }
 
-func (rt *roundTripper) getTransport(req *http.Request) error {
-	switch strings.ToLower(req.URL.Scheme) {
-	case "http":
-		rt.transport = &http.Transport{Dial: rt.Dialer}
-		return nil
-	case "https":
-	default:
-		return fmt.Errorf("meek_lite: invalid URL scheme: '%v'", req.URL.Scheme)
+func getDialerAddress(url *url.URL) string {
+	/*
+	 * If a port has been provided explicitly, use this as part of the connection dialer
+	 * Otherwise fallback to the default port for http/https
+	 */
+	host, port, err := net.SplitHostPort(url.Host)
+	if err == nil {
+		return net.JoinHostPort(host, port)
 	}
 
-	_, err := rt.dialTLS("tcp", getDialTLSAddr(req.URL))
-	switch err {
-	case errProtocolNegotiated:
-	case nil:
-		// Should never happen.
-		panic("meek_lite: dialTLS returned no error when determining transport")
-	default:
-		return err
-	}
-
-	return nil
+	return net.JoinHostPort(url.Host, url.Scheme)
 }
 
-func (rt *roundTripper) dialTLS(network, addr string) (net.Conn, error) {
-	// Unlike rt.transport, this is protected by a critical section
-	// since past the initial manual call from getTransport, the HTTP
-	// client will be the caller.
-	rt.Lock()
-	defer rt.Unlock()
+func urlToHost(url *url.URL) string {
+	addr := getDialerAddress(url)
 
-	// If we have the connection from when we determined the HTTPS
-	// transport to use, return that.
-	if conn := rt.initConn; conn != nil {
-		rt.initConn = nil
-		return conn, nil
-	}
-
-	rawConn, err := rt.Dialer(network, addr)
-	if err != nil {
-		return nil, err
-	}
-
+	var err error
 	var host string
 	if host, _, err = net.SplitHostPort(addr); err != nil {
 		host = addr
 	}
 
-	// TODO: Make this configurable.  What "works" is host dependent.
-	//  * HelloChrome_Auto  - Failures in a stand alone testcase against google.com
-	//  * HelloFirefox_Auto - Fails with the azure bridge, incompatible group.
-	//  * HelloIOS_Auto     - Seems to work.
-	//
-	// Since HelloChrome_Auto works with azure, that's what'll be used for
-	// now, since that's what the overwelming vast majority of people will
-	// use.
-	conn := utls.UClient(rawConn, &utls.Config{ServerName: host}, utls.HelloChrome_Auto)
-	if err = conn.Handshake(); err != nil {
+	return host
+}
+
+func wrapConnectionWithTLS(url *url.URL, rawConnection net.Conn) (*utls.UConn, error) {
+	/*
+	 * Wrap the connection with sensible TLS defaults
+	 */
+
+	// HelloChrome_Auto | HelloFirefox_Auto | HelloIOS_Auto
+	host := urlToHost(url)
+	log.Printf("Performing TLS handshake with server name %s", host)
+	connection := utls.UClient(rawConnection, &utls.Config{ServerName: host}, utls.HelloChrome_Auto)
+
+	if err := connection.Handshake(); err != nil {
 		log.Println("Handshake failed")
-		conn.Close()
+		connection.Close()
 		return nil, err
 	}
 
-	if rt.transport != nil {
-		log.Println("Transport failed")
-		return conn, nil
-	}
-
-	// No http.Transport constructed yet, create one based on the results
-	// of ALPN.
-	switch conn.ConnectionState().NegotiatedProtocol {
-	case http2.NextProtoTLS:
-		// The remote peer is speaking HTTP 2 + TLS.
-		rt.transport = &http2.Transport{DialTLS: rt.dialTLSHTTP2}
-	default:
-		// Assume the remote peer is speaking HTTP 1.x + TLS.
-		rt.transport = &http.Transport{DialTLS: rt.dialTLS}
-	}
-
-	// Stash the connection just established for use servicing the
-	// actual request (should be near-immediate).
-	rt.initConn = conn
-
-	return nil, errProtocolNegotiated
+	return connection, nil
 }
 
-func (rt *roundTripper) dialTLSHTTP2(network, addr string, cfg *tls.Config) (net.Conn, error) {
-	return rt.dialTLS(network, addr)
-}
+func (rt *CustomRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	/*
+	 * Implement our custom roundtrip logic
+	 * This is the only function that's actually required by the http.RoundTripper interface
+	 */
+	// New request, fresh context to track requests
+	dialerContext := rt.dialerSession.NewDialerContext(req)
 
-func getDialTLSAddr(u *url.URL) string {
-	host, port, err := net.SplitHostPort(u.Host)
-	if err == nil {
-		return net.JoinHostPort(host, port)
+	var response *http.Response = nil
+	responseValid := false
+
+	for !responseValid {
+		// Iterate the dialer until we hit on the correct value
+		dialerDefinition := rt.dialerSession.NextDialer(dialerContext)
+		if dialerDefinition == nil {
+			return nil, errors.New("Exhausted dialers")
+		}
+
+		host := dialerDefinition.GetHost(req)
+
+		rt.protocolLock.RLock()
+		protocol, ok := rt.protocolMap[host]
+		rt.protocolLock.RUnlock()
+
+		var err error
+		var connection net.Conn
+
+		if !ok {
+			// We don't have a protocol for this host, so we need to figure it out
+			// Note that there can be multiple `solveProtocol` inflight for the same URL
+			// since we don't have a mutex around the host yet
+			protocol, connection, err = rt.solveProtocol(req, dialerDefinition)
+
+			if err != nil {
+				log.Printf("Unable to solve protocol for %s: %s", host, err)
+				return nil, err
+			}
+			rt.protocolLock.Lock()
+			rt.protocolMap[host] = protocol
+			rt.protocolLock.Unlock()
+		} else {
+			// Create a new connection with the protocol we know
+			connection, err = dialerDefinition.Dial("tcp", getDialerAddress(req.URL))
+			if err != nil {
+				log.Printf("Unable to create connection for %s: %s", host, err)
+				return nil, err
+			}
+
+			// If we have a TLS connection, we need to perform the handshake and wrap the connection
+			if protocol == ProtocolHTTP1TLS || protocol == ProtocolHTTP2TLS {
+				connection, err = wrapConnectionWithTLS(req.URL, connection)
+				if err != nil {
+					log.Printf("Unable to wrap connection for %s: %s", host, err)
+					return nil, err
+				}
+			}
+		}
+		log.Printf("Using protocol %d for %s", protocol, host)
+
+		// At this point the connection has been established so we don't actually need to dial
+		// for the requests; instead use the cached connection since we know the actual
+		// transport is going to be short lived
+		connectionPassthroughDialer := func(network, addr string) (net.Conn, error) {
+			return connection, nil
+		}
+		connectionPassthroughDialerHTTP2 := func(network, addr string, cfg *tls.Config) (net.Conn, error) {
+			return connection, nil
+		}
+
+		var transport http.RoundTripper
+
+		if protocol == ProtocolHTTP1 {
+			transport = &http.Transport{Dial: connectionPassthroughDialer}
+		} else if protocol == ProtocolHTTP1TLS {
+			transport = &http.Transport{DialTLS: connectionPassthroughDialer}
+		} else if protocol == ProtocolHTTP2TLS {
+			transport = &http2.Transport{DialTLS: connectionPassthroughDialerHTTP2}
+		}
+
+		response, err = transport.RoundTrip(req)
+
+		// This should be the return contents for the actual page
+		// Allow 200 messages and 300s (redirects)
+		// Anything in 400s or 500s is an error - note that we include 404 errors here as a resolution error
+		if err == nil && response.StatusCode >= 200 && response.StatusCode < 400 {
+			responseValid = true
+		} else {
+			log.Printf("Invalid response for %s", host)
+
+			// If the response is not valid, we need to close the connection and try again
+			connection.Close()
+		}
 	}
 
-	return net.JoinHostPort(u.Host, u.Scheme)
+	return response, nil
 }
 
-func newRoundTripper() *roundTripper {
-	return &roundTripper{
-		Dialer: net.Dial,
+func (rt *CustomRoundTripper) solveProtocol(request *http.Request, dialerDefinition *DialerDefinition) (int, net.Conn, error) {
+	/*
+	 * Solve the protocol for a given host
+	 * We also pass along the connection for the solved stream in case clients want to immediately
+	 * start using an open connection
+	 */
+	// Create a new connection
+	rawConnection, error := dialerDefinition.Dial("tcp", getDialerAddress(request.URL))
+
+	if error != nil {
+		return -1, nil, error
 	}
-}
 
-func init() {
-	// Attempt to increase compatibility, there's an encrypted link
-	// underneath, and this doesn't (shouldn't) affect the external
-	// fingerprint.
-	utls.EnableWeakCiphers()
+	// If the request is "http" assume we're using HTTP/1.1 since HTTP/2 is only supported over TLS
+	if strings.ToLower(request.URL.Scheme) == "http" {
+		log.Printf("Using HTTP/1.1 for %s", request.URL.Host)
+		return ProtocolHTTP1, rawConnection, nil
+	}
+
+	// Attempt to perform the TLS connection
+	connection, err := wrapConnectionWithTLS(request.URL, rawConnection)
+	if err != nil {
+		return -1, nil, err
+	}
+
+	// Check if we have a successful TLS connection
+	if connection.ConnectionState().HandshakeComplete {
+		// Check if we have a HTTP2 connection
+		if connection.ConnectionState().NegotiatedProtocol == http2.NextProtoTLS {
+			log.Printf("Using HTTP/2TLS for %s", request.URL.Host)
+			return ProtocolHTTP2TLS, connection, nil
+		} else {
+			log.Printf("Using HTTP/1TLS for %s", request.URL.Host)
+			return ProtocolHTTP1TLS, connection, nil
+		}
+	}
+
+	return -1, nil, errors.New("Unable to solve protocol")
 }

--- a/groove/proxy/transport.go
+++ b/groove/proxy/transport.go
@@ -20,9 +20,17 @@ type CustomRoundTripper struct {
 	 * - Support utls handshakes with remote server
 	 */
 
-	// Mapping of host->handler. Note that this is the actual "host" of the dial, might
+	// Mapping of dialer definition identifier->handler. Note that this is the actual "host" of the dial, might
 	// be the end host itself or the proxy server.
-	protocolMap  map[string]http.RoundTripper
+	handlerMap  map[string]map[int]http.RoundTripper
+	handlerLock sync.RWMutex
+
+	// Host protocols are probably the same across definitions, but this might not be true
+	// depending on the MITM properties of the middle proxy. For now we assume that it is in order
+	// to avoid having to make a separate protocol lookup for each dial definition
+	// TODO: Add fallback handling if we fail a lookup by leveraging an outdated host->protocol mapping
+	// [definition][host] -> protocol
+	protocolMap  map[string]int
 	protocolLock sync.RWMutex
 
 	// Dialer session
@@ -37,7 +45,8 @@ const (
 
 func NewCustomRoundTripper(dialerSession *DialerSession) *CustomRoundTripper {
 	return &CustomRoundTripper{
-		protocolMap:   make(map[string]http.RoundTripper),
+		handlerMap:    make(map[string]map[int]http.RoundTripper),
+		protocolMap:   make(map[string]int),
 		dialerSession: dialerSession,
 	}
 }
@@ -46,6 +55,7 @@ func getDialerAddress(url *url.URL) string {
 	/*
 	 * If a port has been provided explicitly, use this as part of the connection dialer
 	 * Otherwise fallback to the default port for http/https
+	 * returns host:port (no scheme prefix)
 	 */
 	host, port, err := net.SplitHostPort(url.Host)
 	if err == nil {
@@ -55,9 +65,7 @@ func getDialerAddress(url *url.URL) string {
 	return net.JoinHostPort(url.Host, url.Scheme)
 }
 
-func urlToHost(url *url.URL) string {
-	addr := getDialerAddress(url)
-
+func addressToHost(addr string) string {
 	var err error
 	var host string
 	if host, _, err = net.SplitHostPort(addr); err != nil {
@@ -67,13 +75,12 @@ func urlToHost(url *url.URL) string {
 	return host
 }
 
-func wrapConnectionWithTLS(url *url.URL, rawConnection net.Conn) (*utls.UConn, error) {
+func wrapConnectionWithTLS(host string, rawConnection net.Conn) (*utls.UConn, error) {
 	/*
 	 * Wrap the connection with sensible TLS defaults
 	 */
 
 	// HelloChrome_Auto | HelloFirefox_Auto | HelloIOS_Auto
-	host := urlToHost(url)
 	log.Printf("Performing TLS handshake with server name %s", host)
 	connection := utls.UClient(rawConnection, &utls.Config{ServerName: host}, utls.HelloChrome_Auto)
 
@@ -104,27 +111,15 @@ func (rt *CustomRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 			return nil, errors.New("Exhausted dialers")
 		}
 
-		host := dialerDefinition.GetHost(req)
-
-		rt.protocolLock.RLock()
-		handler, ok := rt.protocolMap[host]
-		rt.protocolLock.RUnlock()
-
-		var err error
-
-		if !ok {
-			// We don't have a protocol for this host, so we need to figure it out
-			// Note that there can be multiple `solveProtocol` inflight for the same URL
-			// since we don't have a mutex around the host yet
-			handler, err = rt.solveTransport(req, dialerDefinition)
-
-			if err != nil {
-				log.Printf("Unable to solve protocol for %s: %s", host, err)
-				return nil, err
-			}
-			rt.protocolLock.Lock()
-			rt.protocolMap[host] = handler
-			rt.protocolLock.Unlock()
+		protocol, err := rt.solveProtocol(req, dialerDefinition)
+		if err != nil {
+			log.Printf("Failed to solve protocol for %s: %s", req.URL.Host, err)
+			continue
+		}
+		handler, err := rt.solveTransport(protocol, dialerDefinition)
+		if err != nil {
+			log.Printf("Failed to solve transport for %s: %s", dialerDefinition.identifier, err)
+			continue
 		}
 
 		response, err = handler.RoundTrip(req)
@@ -135,7 +130,7 @@ func (rt *CustomRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 		if err == nil && response.StatusCode >= 200 && response.StatusCode < 400 {
 			responseValid = true
 		} else {
-			log.Printf("Invalid response for %s", host)
+			log.Printf("Invalid response for %s", req.URL.String())
 		}
 	}
 
@@ -143,32 +138,81 @@ func (rt *CustomRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 }
 
 func (rt *CustomRoundTripper) solveTransport(
-	request *http.Request,
+	protocol int,
 	dialerDefinition *DialerDefinition,
 ) (http.RoundTripper, error) {
-	// Assume that the protocol will be constant for this given host, which is a reasonable
-	// assumption given the lifespan of the proxy
-	// TODO: Might consider invalidating the transport if we see errors with the connection
-	protocol, _, err := rt.solveProtocol(request, dialerDefinition)
-	log.Printf("Using protocol %d for %s", protocol, request.URL.Host)
+	rt.handlerLock.RLock()
+	handler, ok := rt.handlerMap[dialerDefinition.identifier][protocol]
+	rt.handlerLock.RUnlock()
+
+	if ok {
+		log.Println("Cache hit: transport")
+		return handler, nil
+	}
+
+	// We don't have a handler for this protocol, so we need to figure it out
+	var err error
+	handler, err = rt.solveTransportNew(protocol, dialerDefinition)
 
 	if err != nil {
+		log.Printf("Unable to solve transport for %s: %s", dialerDefinition.identifier, err)
 		return nil, err
 	}
 
+	rt.handlerLock.Lock()
+	if _, ok := rt.handlerMap[dialerDefinition.identifier]; !ok {
+		rt.handlerMap[dialerDefinition.identifier] = make(map[int]http.RoundTripper)
+	}
+	rt.handlerMap[dialerDefinition.identifier][protocol] = handler
+	rt.handlerLock.Unlock()
+
+	return handler, nil
+}
+
+func (rt *CustomRoundTripper) solveProtocol(request *http.Request, dialerDefinition *DialerDefinition) (int, error) {
+	host := getDialerAddress(request.URL)
+
+	rt.protocolLock.RLock()
+	protocol, ok := rt.protocolMap[host]
+	rt.protocolLock.RUnlock()
+
+	if ok {
+		log.Println("Cache hit: protocol")
+		return protocol, nil
+	}
+
+	// We don't have a protocol for this host, so we need to figure it out
+	var err error
+	protocol, err = rt.solveProtocolNew(request, dialerDefinition)
+
+	if err != nil {
+		return -1, err
+	}
+
+	rt.protocolLock.Lock()
+	rt.protocolMap[host] = protocol
+	rt.protocolLock.Unlock()
+
+	return protocol, nil
+}
+
+func (rt *CustomRoundTripper) solveTransportNew(
+	protocol int,
+	dialerDefinition *DialerDefinition,
+) (http.RoundTripper, error) {
 	mainDialer := func(network, addr string) (net.Conn, error) {
 		// Create a new connection with the protocol we know
-		connection, err := dialerDefinition.Dial("tcp", getDialerAddress(request.URL))
+		connection, err := dialerDefinition.Dial(network, addr)
 		if err != nil {
-			log.Printf("Unable to create connection for %s: %s", request.URL.Host, err)
+			log.Printf("Unable to create connection for %s: %s", addr, err)
 			return nil, err
 		}
 
 		// If we have a TLS connection, we need to perform the handshake and wrap the connection
 		if protocol == ProtocolHTTP1TLS || protocol == ProtocolHTTP2TLS {
-			connection, err = wrapConnectionWithTLS(request.URL, connection)
+			connection, err = wrapConnectionWithTLS(addressToHost(addr), connection)
 			if err != nil {
-				log.Printf("Unable to wrap connection for %s: %s", request.URL.Host, err)
+				log.Printf("Unable to wrap connection for %s: %s", addr, err)
 				return nil, err
 			}
 		}
@@ -193,29 +237,29 @@ func (rt *CustomRoundTripper) solveTransport(
 	return transport, nil
 }
 
-func (rt *CustomRoundTripper) solveProtocol(request *http.Request, dialerDefinition *DialerDefinition) (int, net.Conn, error) {
+func (rt *CustomRoundTripper) solveProtocolNew(request *http.Request, dialerDefinition *DialerDefinition) (int, error) {
 	/*
 	 * Solve the protocol for a given host
 	 * We also pass along the connection for the solved stream in case clients want to immediately
 	 * start using an open connection
 	 */
 	// Create a new connection
-	rawConnection, error := dialerDefinition.Dial("tcp", getDialerAddress(request.URL))
+	rawConnection, err := dialerDefinition.Dial("tcp", getDialerAddress(request.URL))
 
-	if error != nil {
-		return -1, nil, error
+	if err != nil {
+		return -1, err
 	}
 
 	// If the request is "http" assume we're using HTTP/1.1 since HTTP/2 is only supported over TLS
 	if strings.ToLower(request.URL.Scheme) == "http" {
 		log.Printf("Using HTTP/1.1 for %s", request.URL.Host)
-		return ProtocolHTTP1, rawConnection, nil
+		return ProtocolHTTP1, nil
 	}
 
 	// Attempt to perform the TLS connection
-	connection, err := wrapConnectionWithTLS(request.URL, rawConnection)
+	connection, err := wrapConnectionWithTLS(addressToHost(getDialerAddress(request.URL)), rawConnection)
 	if err != nil {
-		return -1, nil, err
+		return -1, err
 	}
 
 	// Check if we have a successful TLS connection
@@ -223,12 +267,12 @@ func (rt *CustomRoundTripper) solveProtocol(request *http.Request, dialerDefinit
 		// Check if we have a HTTP2 connection
 		if connection.ConnectionState().NegotiatedProtocol == http2.NextProtoTLS {
 			log.Printf("Using HTTP/2TLS for %s", request.URL.Host)
-			return ProtocolHTTP2TLS, connection, nil
+			return ProtocolHTTP2TLS, nil
 		} else {
 			log.Printf("Using HTTP/1TLS for %s", request.URL.Host)
-			return ProtocolHTTP1TLS, connection, nil
+			return ProtocolHTTP1TLS, nil
 		}
 	}
 
-	return -1, nil, errors.New("Unable to solve protocol")
+	return -1, errors.New("Unable to solve protocol")
 }

--- a/groove/proxy/transport.go
+++ b/groove/proxy/transport.go
@@ -98,6 +98,9 @@ func (rt *CustomRoundTripper) RoundTrip(req *http.Request) (*http.Response, erro
 	 * Implement our custom roundtrip logic
 	 * This is the only function that's actually required by the http.RoundTripper interface
 	 */
+	// Remove additional headers that `removeProxyHeaders` doesn't cover
+	req.Header.Del(ProxyResourceType)
+
 	// New request, fresh context to track requests
 	dialerContext := rt.dialerSession.NewDialerContext(req)
 

--- a/groove/proxy/utilities.go
+++ b/groove/proxy/utilities.go
@@ -10,7 +10,29 @@ func reverseSlice[T any](s []T) {
 	}
 }
 
+func filterSlice[T any](s []T, f func(T) bool) []T {
+	filtered := make([]T, 0)
+
+	for _, value := range s {
+		if f(value) {
+			filtered = append(filtered, value)
+		}
+	}
+
+	return filtered
+}
+
 func containsInt(s []int, search int) bool {
+	for _, value := range s {
+		if value == search {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsString(s []string, search string) bool {
 	for _, value := range s {
 		if value == search {
 			return true


### PR DESCRIPTION
A relatively aggressive change-set to streamline implementation of https://github.com/piercefreeman/grooveproxy/issues/20 and prepare ourselves for browser context linked / rotating proxies, if we go in that direction within the proxy.

Previously dialer references and generators were spread within the codebase even though they were really doing one thing. They all route the data stream (plaintext or TLS) to the open internet through some port host/port dialer using TCP. Since there was only one dialer at a given time (we either used proxies or didn't - it was binary) we could generate this dialer function globally and set it into the proxy instance (primary dialer) and the transport layer (for the round tripper's utls handshake).

Passing through static resources violates this assumption since it means that we need connections open to both a proxy server and the open internet, and attributes of the request itself should determine where we should route it.

One solution was to implement hard-set dialer selection logic within the goproxy or round-tripper, since both contexts have access to the request payload that we need in order to determine whether to proxy or passthrough. But this would have resulted in more scattered logic around different areas and wouldn't support a future implementation where we have multiple proxy servers in rotation, and potentially more complicated business logic to choose the best proxy for a given host. It also doesn't allow us to do request backoff in a clean way, ie. try to passthrough to the open internet with our local connection but fallback to routing through the proxy if our local instance has been blocked.

In this approach we instead say there that can be unlimited dialer functions spawned at any one time. Instead of having static dialers set anywhere, we instead will select from the most relevant currently active dial function via `DialerSession.NextDialer(context)` - passing it an optional request for conditional logic if that request has specific routing logic associated with it. A `DialerContext` maintains the state of a particular outbound request. Once we have dequeued a dialer from the session for the request, it won't be retried for that particular request. This allows us to implement a chaining fallback logic to keep trying different dialers until we have success. This is particularly necessary for the backoff logic sketched out above.

<img width="964" alt="Screen Shot 2022-10-22 at 8 24 54 AM" src="https://user-images.githubusercontent.com/1712066/197347396-626c3482-643d-44c9-a321-e7498dac984f.png">
