### PR TITLE
Add GET-only aggressive cache

### DIFF
--- a/groove/groove-node/index.ts
+++ b/groove/groove-node/index.ts
@@ -203,6 +203,17 @@ export class Groove {
         await checkStatus(response, "Failed to set cache mode.");
     }
 
+    async cacheClear() {
+        const response = await fetchWithTimeout(
+            `${this.baseUrlControl}/api/cache/clear`,
+            {
+                method: "POST",
+                timeout: this.commandTimeout,
+            }
+        )
+        await checkStatus(response, "Failed to clear cache.");
+    }
+
     async dialerLoad(dialers: DialerDefinition[]) {
         const response = await fetchWithTimeout(
             `${this.baseUrlControl}/api/dialer/load`,

--- a/groove/groove-node/index.ts
+++ b/groove/groove-node/index.ts
@@ -12,7 +12,8 @@ import { DialerDefinition, DefaultInternetDialer } from './dialer';
 export const CacheModeEnum = {
 	OFF: 0,
     STANDARD: 1,
-    AGGRESSIVE: 2
+    AGGRESSIVE_GET: 2,
+    AGGRESSIVE: 3
 }
 
 export interface GrooveConfiguration {

--- a/groove/groove-python/groove/enums.py
+++ b/groove/groove-python/groove/enums.py
@@ -5,4 +5,5 @@ class CacheModeEnum(Enum):
     # Ensure enum values are aligned with the cache.go definitions
     OFF = 0
     STANDARD = 1
-    AGGRESSIVE = 2
+    AGGRESSIVE_GET = 2
+    AGGRESSIVE = 3

--- a/groove/groove-python/groove/proxy.py
+++ b/groove/groove-python/groove/proxy.py
@@ -98,6 +98,10 @@ class Groove:
         )
         assert response.json()["success"] == True
 
+    def cache_clear(self):
+        response = self.session.post(urljoin(self.base_url_control, "/api/cache/clear"), timeout=self.timeout)
+        assert response.json()["success"] == True
+
     def dialer_load(self, dialers: list[DialerDefinition]):
         response = self.session.post(
             urljoin(self.base_url_control, "/api/dialer/load"),

--- a/groove/groove-python/groove/tests/conftest.py
+++ b/groove/groove-python/groove/tests/conftest.py
@@ -9,6 +9,8 @@ from groove.proxy import Groove
 def proxy():
     proxy = Groove()
     with proxy.launch():
+        # Before we yield to new client calls clear out any remaining cache items
+        proxy.cache_clear()
         yield proxy
 
 @pytest.fixture(scope="function")

--- a/groove/proxy/cache.go
+++ b/groove/proxy/cache.go
@@ -11,6 +11,8 @@ import (
 
 	goproxy "github.com/piercefreeman/goproxy"
 	"github.com/pquerna/cachecontrol"
+
+	lrucache "grooveproxy/cache"
 )
 
 const (
@@ -47,7 +49,7 @@ type Cache struct {
 
 	// Disk cache comes bundled with a RWMutex so we can call functions directly
 	// and the lock will be handled internally
-	cacheDiskCache *CacheInvalidator
+	cacheDiskCache *lrucache.CacheInvalidator
 
 	inflightRequests map[string]*sync.Mutex
 	lockGeneration   *sync.Mutex
@@ -70,7 +72,7 @@ func NewCache(cacheSizeMaxMB uint64) *Cache {
 
 	return &Cache{
 		mode:               CacheModeStandard,
-		cacheDiskCache:     NewCacheInvalidator(cachePath, 20, 500, 10),
+		cacheDiskCache:     lrucache.NewCacheInvalidator(cachePath, 20, 500, 10),
 		inflightRequests:   map[string]*sync.Mutex{},
 		lockGeneration:     &sync.Mutex{},
 		blockingLocks:      make(map[string]int),

--- a/groove/proxy/cache.go
+++ b/groove/proxy/cache.go
@@ -31,6 +31,10 @@ const (
 	// the upshot of fewer requests to the end server.
 	CacheModeStandard = iota
 
+	// Cache all GET requests. A special case of CacheModeAggressive to allow POST requests to dynamically
+	// update server content.
+	CacheModeGetAggressive = iota
+
 	// Cache everything, regardless of server driven cache status
 	// Like `CacheModeStandard`, this will block until all end requests are resolved. But since we
 	// cache everything here, we are guaranteed that the second request will resolve once the first
@@ -98,7 +102,7 @@ func (c *Cache) SetValidCacheContents(request *http.Request, response *http.Resp
 	// TODO: Explicit handling for redirects?
 	noCacheReasons, expires, _ := cachecontrol.CachableResponse(request, response, cachecontrol.Options{})
 
-	if c.mode == CacheModeAggressive || len(noCacheReasons) == 0 {
+	if c.isModeAggressive(request) || len(noCacheReasons) == 0 {
 		cacheEntry := &CacheEntry{
 			CacheInvalidation: expires,
 			Value:             responseToArchivedResponse(response),
@@ -116,7 +120,7 @@ func (c *Cache) SetFailedCacheContents(request *http.Request, err error) {
 	 * querying that same resource in the future.
 	 * Only applies for aggressive modes
 	 */
-	if c.mode != CacheModeAggressive {
+	if !c.isModeAggressive(request) {
 		return
 	}
 
@@ -155,7 +159,7 @@ func (c *Cache) GetCacheContents(request *http.Request) *CacheEntry {
 	}
 
 	// Determine if the cache is still valid
-	if c.cacheEntryValid(&cache) {
+	if c.cacheEntryValid(request, &cache) {
 		log.Printf("Return cache value: %s (%s)", request.URL.String(), requestKey)
 		return &cache
 	}
@@ -246,18 +250,39 @@ func (c *Cache) Clear() {
 	c.cacheDiskCache.Clear()
 }
 
-func (c *Cache) cacheEntryValid(cacheEntry *CacheEntry) bool {
+func (c *Cache) cacheEntryValid(request *http.Request, cacheEntry *CacheEntry) bool {
 	/*
 	 * Given a cache entry determine if the specified date is still valid
 	 */
 	// If a cache value exists and we are performing aggressive caching, we don't care
 	// about expiration time
-	if c.mode == CacheModeAggressive {
+	if c.isModeAggressive(request) {
 		return true
 	}
 
 	now := time.Now()
 	return now.Before(cacheEntry.CacheInvalidation)
+}
+
+func (c *Cache) isModeAggressive(request *http.Request) bool {
+	/*
+	 * Aggressive modes are a special form of caching, where we will cache everything assuming the request
+	 * meets some properties.
+	 * - CacheModeAggressive: Cache everything
+	 * - CacheModeGetAggressive: Cache all GET requests
+	 *
+	 * This function will return true if the given request should quality for aggressive handling AND if the
+	 * current mode allows for aggressive caching.
+	 */
+	if c.mode == CacheModeAggressive {
+		return true
+	}
+
+	if c.mode == CacheModeGetAggressive && request.Method == "GET" {
+		return true
+	}
+
+	return false
 }
 
 func setupCacheMiddleware(proxy *goproxy.ProxyHttpServer, cache *Cache, recorder *Recorder) {

--- a/groove/proxy/cache/invalidator.go
+++ b/groove/proxy/cache/invalidator.go
@@ -1,7 +1,6 @@
-package main
+package cache
 
 import (
-	"container/list"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -11,123 +10,6 @@ import (
 
 	"github.com/peterbourgon/diskv/v3"
 )
-
-type CacheMetadata struct {
-	/*
-	 * Store properties about the cache entries - these are persisted to disk
-	 * separately from the objects themselves
-	 */
-	Key  string `json:"key"`
-	Size int64  `json:"size"`
-}
-
-type LRUCache struct {
-	/*
-	 * A common API for cache backends that allows for callbacks and invalidation logic
-	 */
-	backingCache any
-
-	// Linked-list, where freshest cache items are at the front and oldest (and closest to invalidation)
-	// are at the end.
-	// Instances of CacheMetadata
-	orderedCacheKeys *list.List
-	keyToElement     map[string]*list.Element
-
-	// Bytes
-	// If `maxSize` is -1, will grow without bound
-	// If instead maxSize is 0, won't populate the LRU cache
-	currentSize int64
-	maxSize     int64
-
-	/*
-	 * User-override functions - each should be implemented for a full LRU implementation
-	 */
-	SetValueCallback func(cache *LRUCache, key string, value *[]byte)
-	GetValueCallback func(cache *LRUCache, key string) (*[]byte, error)
-	HasValueCallback func(cache *LRUCache, key string) bool
-	// Explicit deletion or because of forced cache size validation
-	DeleteKeyCallback func(cache *LRUCache, key string)
-	DeleteAllCallback func(cache *LRUCache)
-}
-
-func NewLRUCache(backingCache any, currentSize int64, maxSize int64) *LRUCache {
-	return &LRUCache{
-		backingCache:     backingCache,
-		orderedCacheKeys: list.New(),
-		keyToElement:     make(map[string]*list.Element),
-		currentSize:      currentSize,
-		maxSize:          maxSize,
-	}
-}
-
-func (cache *LRUCache) Get(key string) (*[]byte, error) {
-	// If so, move it to the front of the list
-	metadata, ok := cache.keyToElement[key]
-	if ok {
-		cache.orderedCacheKeys.MoveToFront(metadata)
-	}
-
-	return cache.GetValueCallback(cache, key)
-}
-
-func (cache *LRUCache) Set(key string, value *[]byte) error {
-	// Determine if this object can fit in the cache
-	metadata := CacheMetadata{
-		Key:  key,
-		Size: int64(len(*value)),
-	}
-
-	// If we are already in the cache, remove the old entry
-	// This will free up the metadata and other attributes before we add a new one
-	// We shouldn't clear out other parts of the cache if we
-	if cache.Has(key) {
-		cache.Delete(key)
-	}
-
-	// Check if either the memory or disk cache would become full with this object and purge accordingly
-	// Purge the oldest entries until we have enough space
-	if cache.maxSize > -1 {
-		for cache.currentSize+metadata.Size > cache.maxSize {
-			oldestElement := cache.orderedCacheKeys.Back()
-			if oldestElement == nil {
-				break
-			}
-			oldestKey := oldestElement.Value.(CacheMetadata).Key
-			cache.Delete(oldestKey)
-		}
-	}
-
-	// It's possible we would still exhaust the memory space, in which case we shouldn't
-	// store it at all. Ensure we stay under the threshold.
-	if cache.currentSize+metadata.Size <= cache.maxSize {
-		cache.SetValueCallback(cache, key, value)
-		cache.currentSize += metadata.Size
-		cache.keyToElement[key] = cache.orderedCacheKeys.PushFront(metadata)
-	}
-
-	return nil
-}
-
-func (cache *LRUCache) Has(key string) bool {
-	return cache.HasValueCallback(cache, key)
-}
-
-func (cache *LRUCache) Delete(key string) {
-	// Housekeeping for the metadata
-	metadata, ok := cache.keyToElement[key]
-	if ok {
-		cache.orderedCacheKeys.Remove(metadata)
-		cache.currentSize -= metadata.Value.(CacheMetadata).Size
-		delete(cache.keyToElement, key)
-	}
-
-	// Perform the actual deletion
-	cache.DeleteKeyCallback(cache, key)
-}
-
-func (cache *LRUCache) DeleteAll() {
-	cache.DeleteAllCallback(cache)
-}
 
 type MemoryCache map[string]*[]byte
 

--- a/groove/proxy/cache/invalidator_test.go
+++ b/groove/proxy/cache/invalidator_test.go
@@ -1,0 +1,38 @@
+package cache
+
+import (
+	"io/ioutil"
+	"testing"
+)
+
+func TestSaveReadIndex(t *testing.T) {
+	cacheDirectory, err := ioutil.TempDir("", "")
+	if err != nil {
+		t.Fatalf("Error creating temp dir: %s", err)
+	}
+
+	invalidator := NewCacheInvalidator(cacheDirectory, 10, 10, 1)
+	invalidator.Set("testKey", &TestSimpleObject{"testValue"})
+
+	// Ensure it saved automatically - should have spanwed a goroutine
+	invalidator.saveWaiter.Wait()
+
+	// Attempt to read the index file
+	fileContents, _, err := invalidator.readIndex()
+
+	if err != nil {
+		t.Fatalf("Error reading index: %s", err)
+	}
+
+	if len(fileContents) != 1 {
+		t.Fatalf("Index should have one entry")
+	}
+
+	if fileContents[0].Key != "testKey" {
+		t.Fatalf("Index should have testKey (actual: %s)", fileContents[0].Key)
+	}
+
+	if fileContents[0].Size == 0 {
+		t.Fatalf("Index should have non-zero size (actual: %d)", fileContents[0].Size)
+	}
+}

--- a/groove/proxy/cache/lru.go
+++ b/groove/proxy/cache/lru.go
@@ -1,0 +1,120 @@
+package cache
+
+import "container/list"
+
+type CacheMetadata struct {
+	/*
+	 * Store properties about the cache entries - these are persisted to disk
+	 * separately from the objects themselves
+	 */
+	Key  string `json:"key"`
+	Size int64  `json:"size"`
+}
+
+type LRUCache struct {
+	/*
+	 * A common API for cache backends that allows for callbacks and invalidation logic
+	 */
+	backingCache any
+
+	// Linked-list, where freshest cache items are at the front and oldest (and closest to invalidation)
+	// are at the end.
+	// Instances of CacheMetadata
+	orderedCacheKeys *list.List
+	keyToElement     map[string]*list.Element
+
+	// Bytes
+	// If `maxSize` is -1, will grow without bound
+	// If instead maxSize is 0, won't populate the LRU cache
+	currentSize int64
+	maxSize     int64
+
+	/*
+	 * User-override functions - each should be implemented for a full LRU implementation
+	 */
+	SetValueCallback func(cache *LRUCache, key string, value *[]byte)
+	GetValueCallback func(cache *LRUCache, key string) (*[]byte, error)
+	HasValueCallback func(cache *LRUCache, key string) bool
+	// Explicit deletion or because of forced cache size validation
+	DeleteKeyCallback func(cache *LRUCache, key string)
+	DeleteAllCallback func(cache *LRUCache)
+}
+
+func NewLRUCache(backingCache any, currentSize int64, maxSize int64) *LRUCache {
+	return &LRUCache{
+		backingCache:     backingCache,
+		orderedCacheKeys: list.New(),
+		keyToElement:     make(map[string]*list.Element),
+		currentSize:      currentSize,
+		maxSize:          maxSize,
+	}
+}
+
+func (cache *LRUCache) Get(key string) (*[]byte, error) {
+	// If so, move it to the front of the list
+	metadata, ok := cache.keyToElement[key]
+	if ok {
+		cache.orderedCacheKeys.MoveToFront(metadata)
+	}
+
+	return cache.GetValueCallback(cache, key)
+}
+
+func (cache *LRUCache) Set(key string, value *[]byte) error {
+	// Determine if this object can fit in the cache
+	metadata := CacheMetadata{
+		Key:  key,
+		Size: int64(len(*value)),
+	}
+
+	// If we are already in the cache, remove the old entry
+	// This will free up the metadata and other attributes before we add a new one
+	// We shouldn't clear out other parts of the cache if we
+	if cache.Has(key) {
+		cache.Delete(key)
+	}
+
+	// Check if either the memory or disk cache would become full with this object and purge accordingly
+	// Purge the oldest entries until we have enough space
+	if cache.maxSize > -1 {
+		for cache.currentSize+metadata.Size > cache.maxSize {
+			oldestElement := cache.orderedCacheKeys.Back()
+			if oldestElement == nil {
+				break
+			}
+			oldestKey := oldestElement.Value.(CacheMetadata).Key
+			cache.Delete(oldestKey)
+		}
+	}
+
+	// It's possible we would still exhaust the memory space, in which case we shouldn't
+	// store it at all. Ensure we stay under the threshold.
+	if cache.currentSize+metadata.Size <= cache.maxSize {
+		cache.SetValueCallback(cache, key, value)
+		cache.currentSize += metadata.Size
+		cache.keyToElement[key] = cache.orderedCacheKeys.PushFront(metadata)
+	}
+
+	return nil
+}
+
+func (cache *LRUCache) Has(key string) bool {
+	return cache.HasValueCallback(cache, key)
+}
+
+func (cache *LRUCache) Delete(key string) {
+	// Housekeeping for the metadata
+	metadata, ok := cache.keyToElement[key]
+	if ok {
+		cache.orderedCacheKeys.Remove(metadata)
+		cache.currentSize -= metadata.Value.(CacheMetadata).Size
+		delete(cache.keyToElement, key)
+	}
+
+	// Perform the actual deletion
+	cache.DeleteKeyCallback(cache, key)
+}
+
+func (cache *LRUCache) DeleteAll() {
+	cache.DeleteAllCallback(cache)
+}

--- a/groove/proxy/cache/lru_test.go
+++ b/groove/proxy/cache/lru_test.go
@@ -1,4 +1,4 @@
-package main
+package cache
 
 import (
 	"io/ioutil"
@@ -110,37 +110,5 @@ func TestLimitedCacheSize(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Key should have saved: %s", err)
 		}
-	}
-}
-
-func TestSaveReadIndex(t *testing.T) {
-	cacheDirectory, err := ioutil.TempDir("", "")
-	if err != nil {
-		t.Fatalf("Error creating temp dir: %s", err)
-	}
-
-	invalidator := NewCacheInvalidator(cacheDirectory, 10, 10, 1)
-	invalidator.Set("testKey", &TestSimpleObject{"testValue"})
-
-	// Ensure it saved automatically - should have spanwed a goroutine
-	invalidator.saveWaiter.Wait()
-
-	// Attempt to read the index file
-	fileContents, _, err := invalidator.readIndex()
-
-	if err != nil {
-		t.Fatalf("Error reading index: %s", err)
-	}
-
-	if len(fileContents) != 1 {
-		t.Fatalf("Index should have one entry")
-	}
-
-	if fileContents[0].Key != "testKey" {
-		t.Fatalf("Index should have testKey (actual: %s)", fileContents[0].Key)
-	}
-
-	if fileContents[0].Size == 0 {
-		t.Fatalf("Index should have non-zero size (actual: %d)", fileContents[0].Size)
 	}
 }

--- a/groove/proxy/cache/utilities.go
+++ b/groove/proxy/cache/utilities.go
@@ -1,0 +1,30 @@
+package cache
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"log"
+)
+
+func objectToBytes(obj any) ([]byte, error) {
+	var writeBuffer bytes.Buffer
+	encoder := gob.NewEncoder(&writeBuffer)
+	err := encoder.Encode(obj)
+	if err != nil {
+		log.Println(fmt.Errorf("Failed to encode cache entry %w", err))
+		return nil, err
+	}
+
+	return writeBuffer.Bytes(), nil
+}
+
+func objectFromBytes(readBuffer []byte, obj any) error {
+	decoder := gob.NewDecoder(bytes.NewReader(readBuffer))
+	err := decoder.Decode(obj)
+	if err != nil {
+		log.Println(fmt.Errorf("Failed to decode cache entry %w", err))
+		return err
+	}
+	return nil
+}

--- a/groove/proxy/cache/utilities_test.go
+++ b/groove/proxy/cache/utilities_test.go
@@ -1,8 +1,12 @@
-package main
+package cache
 
 import (
 	"testing"
 )
+
+type TestSimpleObject struct {
+	Value string
+}
 
 func TestEncodeDecodeObject(t *testing.T) {
 	object := &TestSimpleObject{

--- a/groove/proxy/controller.go
+++ b/groove/proxy/controller.go
@@ -93,9 +93,13 @@ func createController(recorder *Recorder, cache *Cache, dialerSession *DialerSes
 		cache.mode = request.Mode
 		log.Printf("Cache mode set: %d\n", cache.mode)
 
-		if cache.mode == CacheModeOff {
-			cache.Clear()
-		}
+		c.JSON(http.StatusOK, gin.H{
+			"success": true,
+		})
+	})
+
+	router.POST("/api/cache/delete", func(c *gin.Context) {
+		cache.Clear()
 
 		c.JSON(http.StatusOK, gin.H{
 			"success": true,

--- a/groove/proxy/controller.go
+++ b/groove/proxy/controller.go
@@ -98,7 +98,7 @@ func createController(recorder *Recorder, cache *Cache, dialerSession *DialerSes
 		})
 	})
 
-	router.POST("/api/cache/delete", func(c *gin.Context) {
+	router.POST("/api/cache/clear", func(c *gin.Context) {
 		cache.Clear()
 
 		c.JSON(http.StatusOK, gin.H{

--- a/groove/proxy/test_shared.go
+++ b/groove/proxy/test_shared.go
@@ -1,5 +1,0 @@
-package main
-
-type TestSimpleObject struct {
-	Value string
-}

--- a/groove/proxy/utilities.go
+++ b/groove/proxy/utilities.go
@@ -1,10 +1,6 @@
 package main
 
 import (
-	"bytes"
-	"encoding/gob"
-	"fmt"
-	"log"
 	"net/http"
 )
 
@@ -67,26 +63,4 @@ func getRedirectHistory(response *http.Response) ([]*http.Request, []*http.Respo
 	reverseSlice(responseHistory)
 
 	return requestHistory, responseHistory
-}
-
-func objectToBytes(obj any) ([]byte, error) {
-	var writeBuffer bytes.Buffer
-	encoder := gob.NewEncoder(&writeBuffer)
-	err := encoder.Encode(obj)
-	if err != nil {
-		log.Println(fmt.Errorf("Failed to encode cache entry %w", err))
-		return nil, err
-	}
-
-	return writeBuffer.Bytes(), nil
-}
-
-func objectFromBytes(readBuffer []byte, obj any) error {
-	decoder := gob.NewDecoder(bytes.NewReader(readBuffer))
-	err := decoder.Decode(obj)
-	if err != nil {
-		log.Println(fmt.Errorf("Failed to decode cache entry %w", err))
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
Implement a new cache mode that will cache all GET requests, regardless of page failure. This allows us to keep outbound POST requests dynamic while retaining all content that's more likely to be static. Closes out https://github.com/piercefreeman/grooveproxy/issues/26.